### PR TITLE
Introduce StatusEffectManager

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>Covenant - 12v12 Auto Battle Simulation (v0.7)</title>
+    <title>Covenant - 12v12 Auto Battle Simulation (v0.8)</title>
     <style>
         /* CSS는 이전 버전(v0.6)과 동일합니다 */
         body{background-color:#2c3e50;color:white;font-family:sans-serif;display:flex;flex-direction:column;align-items:center;margin:0;padding:20px}h1{text-shadow:2px 2px 4px rgba(0,0,0,.5)}canvas{background-color:#34495e;border:3px solid #7f8c8d;border-radius:10px}#controls{margin-top:15px}button{padding:10px 20px;font-size:16px;border:none;border-radius:8px;cursor:pointer;background:#27ae60;color:white;transition:all .3s ease}button:hover{background:#2ecc71}#log{width:750px;height:100px;background:rgba(0,0,0,.3);border-radius:5px;margin-top:15px;padding:10px;overflow-y:scroll;font-size:14px;border:1px solid #7f8c8d;line-height:1.5}
     </style>
 </head>
 <body>
-    <h1>Covenant - 12vs12 자동 전투 시뮬레이션 (v0.7)</h1>
+    <h1>Covenant - 12vs12 자동 전투 시뮬레이션 (v0.8)</h1>
     <canvas id="gameCanvas" width="750" height="500"></canvas>
     <div id="controls"><button id="startBtn">시뮬레이션 시작</button></div>
     <div id="log"></div>
@@ -25,6 +25,61 @@ const backgroundCanvas = document.createElement('canvas');
 backgroundCanvas.width = canvas.width;
 backgroundCanvas.height = canvas.height;
 const backgroundCtx = backgroundCanvas.getContext('2d');
+
+// [구조개선] 상태이상을 통합 관리하는 중앙 관리자
+class StatusEffectManager {
+    constructor() {
+        // 전투 전체의 모든 활성 상태이상을 여기에서 관리합니다.
+        this.activeEffects = [];
+    }
+
+    // 새로운 상태이상을 관리자에 등록
+    register(caster, target, skill) {
+        const effect = {
+            id: (Math.random() + 1).toString(36).substring(7),
+            caster,
+            target,
+            name: skill.debuff,
+            duration: skill.duration || 1,
+            details: skill.details || {},
+            skill,
+        };
+        this.activeEffects.push(effect);
+        target.statusEffects[effect.name] = effect; // 유닛은 빠른 조회를 위해 참조만 가짐
+        logMessage(`${target.name}(이)가 [${effect.name}] 효과를 얻었습니다! (${effect.duration}턴 지속)`);
+    }
+
+    // 상태이상 제거
+    remove(target, statusName) {
+        if (target.hasStatus && target.hasStatus(statusName)) {
+            this.activeEffects = this.activeEffects.filter(e => !(e.target === target && e.name === statusName));
+            delete target.statusEffects[statusName];
+            logMessage(`${target.name}의 [${statusName}] 효과가 사라졌습니다.`);
+        }
+    }
+    
+    // 턴 종료 시, 모든 효과를 한번에 처리
+    updateTurn() {
+        logMessage("--- 상태이상 효과 정리 시작 ---");
+        // 도트 데미지 및 힐 적용
+        this.activeEffects.forEach(effect => {
+            if (effect.name === 'poison' && !effect.target.isDead) {
+                logMessage(`☠️ ${effect.target.name}(이)가 독 데미지로 ${effect.details.damage} 피해!`);
+                effect.target.takeDamage(effect.details.damage);
+            }
+        });
+
+        // 지속시간 감소 및 만료된 효과 제거
+        this.activeEffects = this.activeEffects.filter(effect => {
+            effect.duration--;
+            if (effect.duration <= 0) {
+                delete effect.target.statusEffects[effect.name];
+                return false; // 배열에서 제거
+            }
+            return true; // 유지
+        });
+    }
+}
 
 const AI_STRATEGIES = {
     aggressive: (unit, enemies) => { const target = unit.findBestTarget(enemies); if (target) { unit.moveTowards(target); if(unit.isInRange(target)) unit.attemptSkillOrAttack(target); }},


### PR DESCRIPTION
## Summary
- implement `StatusEffectManager` to manage active status effects
- bump version display to v0.8

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eb856f76c83279911fee628031075