### PR TITLE
Add manager parameters to skill effects

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -77,16 +77,103 @@ export const UNIT_TEMPLATES = {
 };
 
 export const SKILLS = {
-    powerStrike: { name: '파워 스트라이크', type: 'active', probability: 0.4, effect: (caster, target) => { const damage = Math.floor(caster.getAttackPower() * 1.5); logManager.add(`💥 ${caster.name}의 [파워 스트라이크]! ${target.name}에게 ${damage} 피해!`, 'skill'); target.takeDamage(damage); eventManager.publish('skillUsed', { caster, target, skill: SKILLS.powerStrike }); }},
-    heal: { name: '치유', type: 'active', probability: 0.7, effect: (caster, target) => { const healAmount = Math.floor(caster.getAttackPower() * 2.5); target.hp = Math.min(target.maxHp, target.hp + healAmount); logManager.add(`💖 ${caster.name}의 [치유]! ${target.name}의 체력 ${healAmount} 회복!`, 'heal'); vfxManager.addPopup(`+${healAmount}`, target, '#2ed573'); }},
-    cleanse: { name: '정화', type: 'active', probability: 1.0, effect: (caster, target) => { logManager.add(`✨ ${caster.name}(이)가 ${target.name}에게 [정화] 시전!`, 'skill'); if(target.hasStatus('paralysis')) statusEffectManager.remove(target, 'paralysis'); if(target.hasStatus('confusion')) statusEffectManager.remove(target, 'confusion'); }},
-    paralyzingShot: { name: '마비 화살', type: 'active', probability: 0.3, debuff: 'paralysis', duration: 2, effect: (caster, target) => { logManager.add(`⚡ ${caster.name}(이)가 [마비 화살] 발사!`, 'skill'); statusEffectManager.register(caster, target, SKILLS.paralyzingShot); }},
-    confuseRay: { name: '혼란 광선', type: 'active', probability: 0.2, debuff: 'confusion', duration: 1, effect: (caster, target) => { logManager.add(`😵 ${caster.name}(이)가 [혼란 광선] 발사!`, 'skill'); statusEffectManager.register(caster, target, SKILLS.confuseRay); }},
-    poisonSting: { name: '독침', type: 'active', probability: 0.5, debuff: 'poison', duration: 3, details: { damage: 15 }, effect: (caster, target) => { logManager.add(`☠️ ${caster.name}(이)가 [독침] 공격!`, 'skill'); statusEffectManager.register(caster, target, SKILLS.poisonSting); }},
+    powerStrike: {
+        name: '파워 스트라이크',
+        type: 'active',
+        probability: 0.4,
+        effect: (caster, target, { logManager, eventManager }) => {
+            const damage = Math.floor(caster.getAttackPower() * 1.5);
+            logManager.add(`💥 ${caster.name}의 [파워 스트라이크]! ${target.name}에게 ${damage} 피해!`, 'skill');
+            target.takeDamage(damage);
+            eventManager.publish('skillUsed', { caster, target, skill: SKILLS.powerStrike });
+        }
+    },
+    heal: {
+        name: '치유',
+        type: 'active',
+        probability: 0.7,
+        effect: (caster, target, { logManager, vfxManager }) => {
+            const healAmount = Math.floor(caster.getAttackPower() * 2.5);
+            target.hp = Math.min(target.maxHp, target.hp + healAmount);
+            logManager.add(`💖 ${caster.name}의 [치유]! ${target.name}의 체력 ${healAmount} 회복!`, 'heal');
+            vfxManager.addPopup(`+${healAmount}`, target, '#2ed573');
+        }
+    },
+    cleanse: {
+        name: '정화',
+        type: 'active',
+        probability: 1.0,
+        effect: (caster, target, { logManager, statusEffectManager }) => {
+            logManager.add(`✨ ${caster.name}(이)가 ${target.name}에게 [정화] 시전!`, 'skill');
+            if (target.hasStatus('paralysis')) statusEffectManager.remove(target, 'paralysis');
+            if (target.hasStatus('confusion')) statusEffectManager.remove(target, 'confusion');
+        }
+    },
+    paralyzingShot: {
+        name: '마비 화살',
+        type: 'active',
+        probability: 0.3,
+        debuff: 'paralysis',
+        duration: 2,
+        effect: (caster, target, { logManager, statusEffectManager }) => {
+            logManager.add(`⚡ ${caster.name}(이)가 [마비 화살] 발사!`, 'skill');
+            statusEffectManager.register(caster, target, SKILLS.paralyzingShot);
+        }
+    },
+    confuseRay: {
+        name: '혼란 광선',
+        type: 'active',
+        probability: 0.2,
+        debuff: 'confusion',
+        duration: 1,
+        effect: (caster, target, { logManager, statusEffectManager }) => {
+            logManager.add(`😵 ${caster.name}(이)가 [혼란 광선] 발사!`, 'skill');
+            statusEffectManager.register(caster, target, SKILLS.confuseRay);
+        }
+    },
+    poisonSting: {
+        name: '독침',
+        type: 'active',
+        probability: 0.5,
+        debuff: 'poison',
+        duration: 3,
+        details: { damage: 15 },
+        effect: (caster, target, { logManager, statusEffectManager }) => {
+            logManager.add(`☠️ ${caster.name}(이)가 [독침] 공격!`, 'skill');
+            statusEffectManager.register(caster, target, SKILLS.poisonSting);
+        }
+    },
 
-    stoneSkin: { name: '스톤 스킨', type: 'passive', effect: (caster) => { caster.shield += 20; caster.maxShield += 20; logManager.add(`🛡️ ${caster.name} [스톤 스킨] 발동! 보호막 20 증가!`); }},
-    deathRattle: { name: '죽음의 메아리', type: 'triggered', eventName: 'unitDeath', effect: (payload, owner) => { if (payload.unit === owner) logManager.add(`🔥 ${owner.name}의 [죽음의 메아리] 발동!`); }},
-    vampiricTouch: { name: '흡혈의 손길', type: 'triggered', eventName: 'unitAttack', effect: (payload, owner) => { if (payload.caster === owner) { const healAmount = Math.floor(payload.damage * 0.2); owner.hp = Math.min(owner.maxHp, owner.hp + healAmount); logManager.add(`🩸 ${owner.name}이 [흡혈의 손길]로 체력을 ${healAmount} 회복!`, 'heal'); vfxManager.addPopup(`+${healAmount}`, owner, '#2ed573'); }}}
+    stoneSkin: {
+        name: '스톤 스킨',
+        type: 'passive',
+        effect: (caster, _target, { logManager }) => {
+            caster.shield += 20;
+            caster.maxShield += 20;
+            logManager.add(`🛡️ ${caster.name} [스톤 스킨] 발동! 보호막 20 증가!`);
+        }
+    },
+    deathRattle: {
+        name: '죽음의 메아리',
+        type: 'triggered',
+        eventName: 'unitDeath',
+        effect: (payload, owner, { logManager }) => {
+            if (payload.unit === owner) logManager.add(`🔥 ${owner.name}의 [죽음의 메아리] 발동!`);
+        }
+    },
+    vampiricTouch: {
+        name: '흡혈의 손길',
+        type: 'triggered',
+        eventName: 'unitAttack',
+        effect: (payload, owner, { logManager, vfxManager }) => {
+            if (payload.caster === owner) {
+                const healAmount = Math.floor(payload.damage * 0.2);
+                owner.hp = Math.min(owner.maxHp, owner.hp + healAmount);
+                logManager.add(`🩸 ${owner.name}이 [흡혈의 손길]로 체력을 ${healAmount} 회복!`, 'heal');
+                vfxManager.addPopup(`+${healAmount}`, owner, '#2ed573');
+            }
+        }
+    }
 };
 
 export const CLASS_STATS = {

--- a/js/unit.js
+++ b/js/unit.js
@@ -42,7 +42,8 @@ export class Unit {
             const skill = SKILLS[key];
             if (skill && skill.type === 'triggered') {
                 eventManager.subscribe(skill.eventName, (payload) => {
-                    if(!this.isDead) skill.effect(payload, this)
+                    if (!this.isDead)
+                        skill.effect(payload, this, { logManager, eventManager, vfxManager, statusEffectManager });
                 });
             }
         });
@@ -80,7 +81,13 @@ export class Unit {
         return enemies.reduce((closest, current) => (this.getDistance(current) < this.getDistance(closest) ? current : closest));
     }
     
-    applyPassiveSkills() { this.skills.forEach(key => SKILLS[key]?.type === 'passive' && SKILLS[key].effect(this)); }
+    applyPassiveSkills() {
+        this.skills.forEach(key => {
+            if (SKILLS[key]?.type === 'passive') {
+                SKILLS[key].effect(this, null, { logManager, eventManager, vfxManager, statusEffectManager });
+            }
+        });
+    }
     
     getAttackPower() {
         const base = this.attackPower + this.bonusAttack + this.contextualBonus.attack;
@@ -110,7 +117,8 @@ export class Unit {
     hasSkill(name) { return this.skills.some(key => SKILLS[key]?.name === name); }
     useSkill(skillName, target) {
         const skillKey = this.skills.find(key => SKILLS[key]?.name === skillName);
-        if (skillKey) SKILLS[skillKey].effect(this, target);
+        if (skillKey)
+            SKILLS[skillKey].effect(this, target, { logManager, eventManager, vfxManager, statusEffectManager });
     }
     
     attemptSkillOrAttack(target) {


### PR DESCRIPTION
## Summary
- update SKILLS in `js/data.js` so each effect receives managers
- update `Unit` methods to pass manager objects to skill effects
- adjust old `game.js` logic for new effect signature

## Testing
- `node -c js/data.js`
- `node -c js/unit.js`
- `node -c js/game.js`


------
https://chatgpt.com/codex/tasks/task_e_684f32e54cf88327b35308f9275c0c2a