### PR TITLE
Update Unit to use manager injection

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -407,7 +407,7 @@ function init() {
     playerUnits = playerTemplates.map((key, i) => {
         const x = Math.floor(i / 5);
         const y = (i % 5) * 2;
-        return new Unit(UNIT_TEMPLATES[key], "player", x, y);
+        return new Unit(UNIT_TEMPLATES[key], "player", x, y, { logManager, eventManager, vfxManager, statusEffectManager });
     });
 
     const enemyTemplates = [
@@ -417,7 +417,7 @@ function init() {
     enemyUnits = enemyTemplates.map((key, i) => {
         const x = (GRID_COLS - 1) - Math.floor(i / 5);
         const y = (i % 5) * 2;
-        return new Unit(UNIT_TEMPLATES[key], "enemy", x, y);
+        return new Unit(UNIT_TEMPLATES[key], "enemy", x, y, { logManager, eventManager, vfxManager, statusEffectManager });
     });
     
     allUnits=[...playerUnits,...enemyUnits];

--- a/js/main.js
+++ b/js/main.js
@@ -42,8 +42,8 @@ function init() {
     const playerTemplates = ['p_knight','p_warrior','p_cavalry','p_archer','p_mage','p_healer'];
     const enemyTemplates = ['e_troll','e_warrior','e_cavalry','e_archer','e_mage','e_shaman'];
     
-    playerUnits = playerTemplates.map((key, i) => new Unit(UNIT_TEMPLATES[key], "player", 1, i + 2));
-    enemyUnits = enemyTemplates.map((key, i) => new Unit(UNIT_TEMPLATES[key], "enemy", GRID_COLS - 2, i + 2));
+    playerUnits = playerTemplates.map((key, i) => new Unit(UNIT_TEMPLATES[key], "player", 1, i + 2, { logManager, eventManager, vfxManager, statusEffectManager }));
+    enemyUnits = enemyTemplates.map((key, i) => new Unit(UNIT_TEMPLATES[key], "enemy", GRID_COLS - 2, i + 2, { logManager, eventManager, vfxManager, statusEffectManager }));
     
     allUnits=[...playerUnits,...enemyUnits];
 


### PR DESCRIPTION
## Summary
- inject manager references when creating a `Unit`
- forward stored managers when running passive and active skill effects
- update game initialization code to pass managers to units

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f345968c48327bbf5df3e2549b7ac