### PR TITLE
Fix status effect logging

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -211,7 +211,7 @@ class StatusEffectManager {
         });
     }
 }
-const statusEffectManager = new StatusEffectManager();
+const statusEffectManager = new StatusEffectManager(logManager);
 const eventManager = new EventManager();
 
 const AI_STRATEGIES = {

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,7 @@ const CELL_SIZE = 50, GRID_COLS = 15, GRID_ROWS = 10;
 const logManager = new BattleLogManager(document.getElementById('log'));
 const vfxManager = new VisualEffectManager();
 const eventManager = new EventManager();
-const statusEffectManager = new StatusEffectManager();
+const statusEffectManager = new StatusEffectManager(logManager);
 
 const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster };
 const uiControls = { startBtn };

--- a/js/managers.js
+++ b/js/managers.js
@@ -82,7 +82,10 @@ export class EventManager {
 }
 
 export class StatusEffectManager {
-    constructor() { this.activeEffects = []; }
+    constructor(logManager) {
+        this.activeEffects = [];
+        this.logManager = logManager;
+    }
     register(caster, target, skill) {
         const effect = {
             id: (Math.random() + 1).toString(36).substring(7),
@@ -94,19 +97,19 @@ export class StatusEffectManager {
         };
         this.activeEffects.push(effect);
         target.statusEffects[effect.name] = effect;
-        logManager.add(`${target.name}(이)가 [${effect.name}] 효과를 얻었습니다! (${effect.duration}턴 지속)`);
+        this.logManager.add(`${target.name}(이)가 [${effect.name}] 효과를 얻었습니다! (${effect.duration}턴 지속)`);
     }
     remove(target, statusName) {
         if (target.hasStatus(statusName)) {
             this.activeEffects = this.activeEffects.filter(e => !(e.target === target && e.name === statusName));
             delete target.statusEffects[statusName];
-            logManager.add(`${target.name}의 [${statusName}] 효과가 사라졌습니다.`);
+            this.logManager.add(`${target.name}의 [${statusName}] 효과가 사라졌습니다.`);
         }
     }
     updateTurn() {
         this.activeEffects.forEach(effect => {
             if (effect.name === 'poison' && !effect.target.isDead) {
-                logManager.add(`☠️ ${effect.target.name}(이)가 독 데미지로 ${effect.details.damage} 피해!`, 'attack');
+                this.logManager.add(`☠️ ${effect.target.name}(이)가 독 데미지로 ${effect.details.damage} 피해!`, 'attack');
                 effect.target.takeDamage(effect.details.damage);
             }
         });


### PR DESCRIPTION
## Summary
- fix `StatusEffectManager` to accept a log manager
- update `main.js` and `game.js` to pass the log manager

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa46f8ec8327a2767993cf2e0ad8