### PR TITLE
Introduce SimulationManager and refine AI

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,14 +9,11 @@ import {
     battleMaster,
     AiManager,
     MetaAiManager,
+    SimulationManager,
 } from './managers/index.js';
-import { CombatManager } from './combatManager.js';
 
 // --- 전역 변수 및 UI 요소 ---
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
 const startBtn = document.getElementById('startBtn');
-const CELL_SIZE = 50, GRID_COLS = 15, GRID_ROWS = 10;
 
 // --- 매니저 인스턴스 생성 ---
 const logManager = new BattleLogManager(document.getElementById('log'));
@@ -29,78 +26,8 @@ const aiManager = new AiManager(metaAiManager);
 const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster, aiManager, metaAiManager };
 const uiControls = { startBtn };
 
-// --- CombatManager 인스턴스 생성 ---
-const combatManager = new CombatManager(allManagers, uiControls);
-
-// --- 렌더링 관련 함수 ---
-const backgroundCanvas = document.createElement('canvas');
-backgroundCanvas.width = canvas.width;
-backgroundCanvas.height = canvas.height;
-const backgroundCtx = backgroundCanvas.getContext('2d');
-
-function preRenderGrid() {
-    backgroundCtx.strokeStyle = '#7f8c8d';
-    backgroundCtx.lineWidth = 1;
-    for (let i = 0; i <= GRID_COLS; i++) {
-        backgroundCtx.beginPath();
-        backgroundCtx.moveTo(i * CELL_SIZE, 0);
-        backgroundCtx.lineTo(i * CELL_SIZE, GRID_ROWS * CELL_SIZE);
-        backgroundCtx.stroke();
-    }
-    for (let i = 0; i <= GRID_ROWS; i++) {
-        backgroundCtx.beginPath();
-        backgroundCtx.moveTo(0, i * CELL_SIZE);
-        backgroundCtx.lineTo(GRID_COLS * CELL_SIZE, i * CELL_SIZE);
-        backgroundCtx.stroke();
-    }
-}
-
-function drawUnits(units) {
-    units.forEach(unit => {
-        if (unit.isDead) return;
-        const x = unit.x * CELL_SIZE + CELL_SIZE / 2;
-        const y = unit.y * CELL_SIZE + CELL_SIZE / 2;
-        ctx.font = '24px sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(unit.icon, x, y);
-        ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
-        ctx.beginPath();
-        ctx.arc(x, y + 15, 5, 0, 2 * Math.PI);
-        ctx.fill();
-        const hpBarWidth = CELL_SIZE * 0.8;
-        const hpRatio = unit.hp / unit.maxHp;
-        ctx.fillStyle = '#555';
-        ctx.fillRect(x - hpBarWidth / 2, y - 20, hpBarWidth, 5);
-        ctx.fillStyle = 'green';
-        ctx.fillRect(x - hpBarWidth / 2, y - 20, hpBarWidth * hpRatio, 5);
-        if (unit.maxShield > 0) {
-            const shieldRatio = unit.shield / unit.maxShield;
-            ctx.fillStyle = '#555';
-            ctx.fillRect(x - hpBarWidth / 2, y - 26, hpBarWidth, 5);
-            ctx.fillStyle = 'cyan';
-            ctx.fillRect(x - hpBarWidth / 2, y - 26, hpBarWidth * shieldRatio, 5);
-        }
-        vfxManager.drawStatusIcons(ctx, unit);
-    });
-}
-
-function render(units) {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(backgroundCanvas, 0, 0);
-    if (units) {
-        drawUnits(units);
-    }
-    vfxManager.draw(ctx);
-}
-
-// --- 이벤트 리스너 ---
-startBtn.addEventListener('click', () => {
-    combatManager.startSimulation(render);
-});
+const simulationManager = new SimulationManager(allManagers, uiControls);
 
 window.onload = () => {
-    preRenderGrid();
-    combatManager.init();
-    render(combatManager.allUnits);
+    simulationManager.init();
 };

--- a/js/managers/AiManager.js
+++ b/js/managers/AiManager.js
@@ -1,3 +1,5 @@
+import { SKILLS } from '../../src/data/skills.js';
+
 export class AiManager {
     constructor(metaManager = null) {
         this.metaManager = metaManager;
@@ -21,7 +23,7 @@ export class AiManager {
                 const target = unit.findBestTarget(enemies);
                 if (target) {
                     const distance = unit.getDistance(target);
-                    const safeDistance = unit.range > 1 ? unit.range - 1 : 1;
+                    const safeDistance = Math.max(1, unit.range - 1);
                     if (distance < safeDistance) {
                         unit.moveAwayFrom(target);
                     } else if (distance > unit.range) {
@@ -62,8 +64,11 @@ export class AiManager {
                 if (healTarget && unit.hasSkill('heal')) {
                     unit.moveTowards(healTarget, true);
                     if (unit.isInRange(healTarget)) {
-                        unit.useSkill('heal', healTarget);
-                        return;
+                        const healSkill = SKILLS[unit.skills.find(key => SKILLS[key]?.name === '치유')];
+                        if (!healSkill || Math.random() < healSkill.probability) {
+                            unit.useSkill('heal', healTarget);
+                            return;
+                        }
                     }
                 }
                 this.strategies.kiting(unit, enemies, allies);

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -1,0 +1,83 @@
+import { CombatManager } from '../combatManager.js';
+
+export class SimulationManager {
+    constructor(managers, uiControls) {
+        this.combatManager = new CombatManager(managers, uiControls);
+        this.canvas = document.getElementById('gameCanvas');
+        this.ctx = this.canvas.getContext('2d');
+        this.startBtn = uiControls.startBtn;
+        this.CELL_SIZE = 50;
+        this.GRID_COLS = 15;
+        this.GRID_ROWS = 10;
+
+        this.backgroundCanvas = document.createElement('canvas');
+        this.backgroundCanvas.width = this.canvas.width;
+        this.backgroundCanvas.height = this.canvas.height;
+        this.backgroundCtx = this.backgroundCanvas.getContext('2d');
+    }
+
+    preRenderGrid() {
+        this.backgroundCtx.strokeStyle = '#7f8c8d';
+        this.backgroundCtx.lineWidth = 1;
+        for (let i = 0; i <= this.GRID_COLS; i++) {
+            this.backgroundCtx.beginPath();
+            this.backgroundCtx.moveTo(i * this.CELL_SIZE, 0);
+            this.backgroundCtx.lineTo(i * this.CELL_SIZE, this.GRID_ROWS * this.CELL_SIZE);
+            this.backgroundCtx.stroke();
+        }
+        for (let i = 0; i <= this.GRID_ROWS; i++) {
+            this.backgroundCtx.beginPath();
+            this.backgroundCtx.moveTo(0, i * this.CELL_SIZE);
+            this.backgroundCtx.lineTo(this.GRID_COLS * this.CELL_SIZE, i * this.CELL_SIZE);
+            this.backgroundCtx.stroke();
+        }
+    }
+
+    drawUnits(units) {
+        units.forEach(unit => {
+            if (unit.isDead) return;
+            const x = unit.x * this.CELL_SIZE + this.CELL_SIZE / 2;
+            const y = unit.y * this.CELL_SIZE + this.CELL_SIZE / 2;
+            this.ctx.font = '24px sans-serif';
+            this.ctx.textAlign = 'center';
+            this.ctx.textBaseline = 'middle';
+            this.ctx.fillText(unit.icon, x, y);
+            this.ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
+            this.ctx.beginPath();
+            this.ctx.arc(x, y + 15, 5, 0, 2 * Math.PI);
+            this.ctx.fill();
+            const barWidth = this.CELL_SIZE * 0.8;
+            const hpRatio = unit.hp / unit.maxHp;
+            this.ctx.fillStyle = '#555';
+            this.ctx.fillRect(x - barWidth / 2, y - 20, barWidth, 5);
+            this.ctx.fillStyle = 'green';
+            this.ctx.fillRect(x - barWidth / 2, y - 20, barWidth * hpRatio, 5);
+            if (unit.maxShield > 0) {
+                const shieldRatio = unit.shield / unit.maxShield;
+                this.ctx.fillStyle = '#555';
+                this.ctx.fillRect(x - barWidth / 2, y - 26, barWidth, 5);
+                this.ctx.fillStyle = 'cyan';
+                this.ctx.fillRect(x - barWidth / 2, y - 26, barWidth * shieldRatio, 5);
+            }
+            this.combatManager.managers.vfxManager.drawStatusIcons(this.ctx, unit);
+        });
+    }
+
+    render(units) {
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.drawImage(this.backgroundCanvas, 0, 0);
+        if (units) {
+            this.drawUnits(units);
+        }
+        this.combatManager.managers.vfxManager.draw(this.ctx);
+    }
+
+    init() {
+        this.preRenderGrid();
+        this.combatManager.init();
+        this.render(this.combatManager.allUnits);
+        this.startBtn.addEventListener('click', () => {
+            this.combatManager.startSimulation(units => this.render(units));
+        });
+    }
+}

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -5,3 +5,4 @@ export { StatusEffectManager } from './StatusEffectManager.js';
 export { battleMaster } from './BattleMaster.js';
 export { AiManager } from './AiManager.js';
 export { MetaAiManager } from './MetaAiManager.js';
+export { SimulationManager } from './SimulationManager.js';


### PR DESCRIPTION
## Summary
- add new `SimulationManager` to handle rendering and start logic
- tweak AI manager to use safer kiting distance and probabilistic healing
- export `SimulationManager` via managers index
- update main entry to use `SimulationManager`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867bb6438c88327a42b1962eef34e6d