### PR TITLE
Fix units freezing after first turn

### DIFF
--- a/js/combatManager.js
+++ b/js/combatManager.js
@@ -95,6 +95,8 @@ export class CombatManager {
 
         this.managers.logManager.add("--- 새로운 턴 시작 ---");
         const turnOrder = this.allUnits.filter(u => !u.isDead).sort((a, b) => a.weight - b.weight);
+        // 모든 유닛의 행동 여부를 새 턴마다 초기화합니다.
+        turnOrder.forEach(u => (u.hasActed = false));
 
         for (const unit of turnOrder) {
             if (unit.isDead || !this.isSimulationRunning) continue;


### PR DESCRIPTION
## Summary
- reset each unit's `hasActed` flag at the start of every turn

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867e33bb438832787b34735ea966526