### PR TITLE
Fix battle log timing

### DIFF
--- a/js/combatManager.js
+++ b/js/combatManager.js
@@ -103,6 +103,7 @@ export class CombatManager {
             const enemies = unit.team === 'player' ? this.enemyUnits.filter(u => !u.isDead) : this.playerUnits.filter(u => !u.isDead);
             const allies = unit.team === 'player' ? this.playerUnits.filter(u => !u.isDead) : this.enemyUnits.filter(u => !u.isDead);
             unit.takeTurn(enemies, allies);
+            this.managers.logManager.flush();
             await this.sleep(100);
         }
 

--- a/js/game.js
+++ b/js/game.js
@@ -280,6 +280,7 @@ async function runTurn() {
                 ? playerUnits.filter(u => !u.isDead)
                 : enemyUnits.filter(u => !u.isDead);
         unit.takeTurn(enemies, allies);
+        logManager.flush();
         await sleep(100);
     }
 


### PR DESCRIPTION
## Summary
- flush the battle log after every unit acts to keep it in sync with the battle action

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867e6ba5fe083279faf549ac8ab4af4