### PR TITLE
Add image manager and enlarge tiles

### DIFF
--- a/battlefield_sample.html
+++ b/battlefield_sample.html
@@ -48,8 +48,8 @@
         
         .battle-grid {
             display: grid;
-            grid-template-columns: repeat(15, 50px);
-            grid-template-rows: repeat(10, 50px);
+            grid-template-columns: repeat(15, 192px);
+            grid-template-rows: repeat(10, 192px);
             gap: 2px;
             justify-content: center;
             margin: 20px auto;
@@ -60,8 +60,8 @@
         }
         
         .grid-cell {
-            width: 50px;
-            height: 50px;
+            width: 192px;
+            height: 192px;
             border: 1px solid #34495e;
             display: flex;
             align-items: center;
@@ -162,14 +162,14 @@
         
         @media (max-width: 768px) {
             .battle-grid {
-                grid-template-columns: repeat(15, 35px);
-                grid-template-rows: repeat(10, 35px);
+                grid-template-columns: repeat(15, 134px);
+                grid-template-rows: repeat(10, 134px);
                 gap: 1px;
             }
             
             .grid-cell {
-                width: 35px;
-                height: 35px;
+                width: 134px;
+                height: 134px;
                 font-size: 18px;
             }
         }

--- a/css/style.css
+++ b/css/style.css
@@ -39,7 +39,7 @@ button:hover {
 }
 
 #log {
-    width: 750px;
+    width: 2880px;
     height: 100px;
     background: rgba(0,0,0,.3);
     border-radius: 5px;

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <h1>Covenant - 전투 시뮬레이션</h1>
-    <canvas id="gameCanvas" width="750" height="500"></canvas>
+    <canvas id="gameCanvas" width="2880" height="1920"></canvas>
     <div id="controls"><button id="startBtn">시뮬레이션 시작</button></div>
     <div id="log"></div>
 

--- a/js/data.js
+++ b/js/data.js
@@ -22,9 +22,9 @@ export const UNIT_TEMPLATES = {
 
 
 export const CLASS_STATS = {
-    Warrior:  { range: 1, moveSpeed: 3, icon: '⚔️' },
-    Cavalry:  { range: 2, moveSpeed: 5, icon: '🐎' },
-    Archer:   { range: 4, moveSpeed: 3, icon: '🏹' },
-    Mage:     { range: 3, moveSpeed: 2, icon: '🔮' },
-    Healer:   { range: 3, moveSpeed: 3, icon: '💖' }
+    Warrior:  { range: 1, moveSpeed: 3, icon: '⚔️', image: 'assets/images/warrior.png' },
+    Cavalry:  { range: 2, moveSpeed: 5, icon: '🐎', image: 'assets/images/paladin.png' },
+    Archer:   { range: 4, moveSpeed: 3, icon: '🏹', image: 'assets/images/archer.png' },
+    Mage:     { range: 3, moveSpeed: 2, icon: '🔮', image: 'assets/images/wizard.png' },
+    Healer:   { range: 3, moveSpeed: 3, icon: '💖', image: 'assets/images/healer.png' }
 };

--- a/js/game.js
+++ b/js/game.js
@@ -9,7 +9,7 @@ import { battleMaster } from './managers/BattleMaster.js';
 
 const canvas = document.getElementById('gameCanvas'), ctx = canvas.getContext('2d');
 const startBtn = document.getElementById('startBtn'), logElement = document.getElementById('log');
-const GRID_COLS = 15, GRID_ROWS = 10, CELL_SIZE = 50;
+const GRID_COLS = 15, GRID_ROWS = 10, CELL_SIZE = 192;
 const backgroundCanvas = document.createElement('canvas');
 backgroundCanvas.width = canvas.width;
 backgroundCanvas.height = canvas.height;

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,7 @@ import {
     SimulationManager,
     DelayManager,
     AnimationManager,
+    ImageManager,
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
@@ -26,8 +27,9 @@ const metaAiManager = new MetaAiManager();
 const aiManager = new AiManager(metaAiManager);
 const delayManager = new DelayManager();
 const animationManager = new AnimationManager(delayManager);
+const imageManager = new ImageManager();
 
-const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster, aiManager, metaAiManager, delayManager, animationManager };
+const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster, aiManager, metaAiManager, delayManager, animationManager, imageManager };
 const uiControls = { startBtn };
 
 const simulationManager = new SimulationManager(allManagers, uiControls);

--- a/js/managers/ImageManager.js
+++ b/js/managers/ImageManager.js
@@ -1,0 +1,24 @@
+export class ImageManager {
+    constructor() {
+        this.cache = new Map();
+    }
+
+    load(path) {
+        if (this.cache.has(path)) {
+            return Promise.resolve(this.cache.get(path));
+        }
+        return new Promise((resolve, reject) => {
+            const img = new Image();
+            img.src = path;
+            img.onload = () => {
+                this.cache.set(path, img);
+                resolve(img);
+            };
+            img.onerror = reject;
+        });
+    }
+
+    get(path) {
+        return this.cache.get(path);
+    }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -6,9 +6,11 @@ export class SimulationManager {
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
         this.startBtn = uiControls.startBtn;
-        this.CELL_SIZE = 50;
+        this.CELL_SIZE = 192;
         this.GRID_COLS = 15;
         this.GRID_ROWS = 10;
+
+        this.imageManager = managers.imageManager;
 
         this.backgroundCanvas = document.createElement('canvas');
         this.backgroundCanvas.width = this.canvas.width;
@@ -38,10 +40,22 @@ export class SimulationManager {
             if (unit.isDead) return;
             const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
             const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE / 2;
-            this.ctx.font = '24px sans-serif';
-            this.ctx.textAlign = 'center';
-            this.ctx.textBaseline = 'middle';
-            this.ctx.fillText(unit.icon, drawX, drawY);
+            if (unit.sprite) {
+                if (unit.team === 'enemy') {
+                    this.ctx.save();
+                    this.ctx.translate(drawX, drawY);
+                    this.ctx.scale(-1, 1);
+                    this.ctx.drawImage(unit.sprite, -this.CELL_SIZE / 2, -this.CELL_SIZE / 2, this.CELL_SIZE, this.CELL_SIZE);
+                    this.ctx.restore();
+                } else {
+                    this.ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE / 2, drawY - this.CELL_SIZE / 2, this.CELL_SIZE, this.CELL_SIZE);
+                }
+            } else {
+                this.ctx.font = '24px sans-serif';
+                this.ctx.textAlign = 'center';
+                this.ctx.textBaseline = 'middle';
+                this.ctx.fillText(unit.icon, drawX, drawY);
+            }
             this.ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
             this.ctx.beginPath();
             this.ctx.arc(drawX, drawY + 15, 5, 0, 2 * Math.PI);
@@ -72,9 +86,16 @@ export class SimulationManager {
         this.combatManager.managers.vfxManager.draw(this.ctx);
     }
 
-    init() {
+    loadUnitSprites() {
+        const units = this.combatManager.allUnits;
+        const promises = units.map(u => this.imageManager.load(u.image).then(img => { u.sprite = img; }));
+        return Promise.all(promises);
+    }
+
+    async init() {
         this.preRenderGrid();
         this.combatManager.init();
+        await this.loadUnitSprites();
         this.render(this.combatManager.allUnits);
         this.startBtn.addEventListener('click', () => {
             this.combatManager.startSimulation(units => this.render(units));

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -8,3 +8,4 @@ export { MetaAiManager } from './MetaAiManager.js';
 export { SimulationManager } from './SimulationManager.js';
 export { DelayManager } from './DelayManager.js';
 export { AnimationManager } from './AnimationManager.js';
+export { ImageManager } from './ImageManager.js';

--- a/js/unit.js
+++ b/js/unit.js
@@ -13,6 +13,8 @@ export class Unit {
         this.maxHp = this.hp;
         this.skills = template.skills || [];
         Object.assign(this, CLASS_STATS[this.classType]);
+        this.image = CLASS_STATS[this.classType].image;
+        this.sprite = null;
         this.isDead = false; this.hasActed = false;
         this.shield = this.valor * 2; this.maxShield = this.shield;
         this.bonusAttack = 0;

--- a/world_mab_sample.html
+++ b/world_mab_sample.html
@@ -25,8 +25,8 @@
         }
         .dungeon {
             display: grid;
-            grid-template-columns: repeat(10, 40px);
-            grid-template-rows: repeat(10, 40px);
+            grid-template-columns: repeat(10, 192px);
+            grid-template-rows: repeat(10, 192px);
             gap: 2px;
             background-color: #333;
             padding: 10px;
@@ -34,8 +34,8 @@
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
         }
         .cell {
-            width: 40px;
-            height: 40px;
+            width: 192px;
+            height: 192px;
             display: flex;
             justify-content: center;
             align-items: center;


### PR DESCRIPTION
## Summary
- adjust battlefield and dungeon tiles to 192px
- implement `ImageManager` and load unit sprites
- update simulation to draw images and flip enemy sprites
- resize canvas and log panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867edfa5ddc8327a396f0783bf5335d