### PR TITLE
Fix disappearing sprites on turn start

### DIFF
--- a/js/combatManager.js
+++ b/js/combatManager.js
@@ -63,12 +63,21 @@ export class CombatManager {
     }
 
     // 시뮬레이션 시작
-    startSimulation(renderCallback) {
+    async startSimulation(renderCallback) {
         if (this.isSimulationRunning) return;
         this.isSimulationRunning = true;
         this.ui.startBtn.disabled = true;
 
         this.init();
+        if (this.managers.imageManager) {
+            const units = this.allUnits;
+            const promises = units.map(u =>
+                this.managers.imageManager.load(u.image).then(img => {
+                    u.sprite = img;
+                })
+            );
+            await Promise.all(promises);
+        }
         this.runTurn(); // 최초 턴 실행
 
         const loop = () => {

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -97,8 +97,8 @@ export class SimulationManager {
         this.combatManager.init();
         await this.loadUnitSprites();
         this.render(this.combatManager.allUnits);
-        this.startBtn.addEventListener('click', () => {
-            this.combatManager.startSimulation(units => this.render(units));
+        this.startBtn.addEventListener('click', async () => {
+            await this.combatManager.startSimulation(units => this.render(units));
         });
     }
 }


### PR DESCRIPTION
## Summary
- reload unit sprites every time a simulation starts
- handle async start logic so sprites are ready before actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867f22e57088327802eca8cbdce5e5a