### PR TITLE
Implement Y mapping for unit sprites

### DIFF
--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -36,44 +36,50 @@ export class SimulationManager {
     }
 
     drawUnits(units) {
-        units.forEach(unit => {
+        const sorted = [...units].sort((a, b) => ((a.renderY ?? a.y) - (b.renderY ?? b.y)));
+        sorted.forEach(unit => {
             if (unit.isDead) return;
-            const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
-            const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE / 2;
+            const baseX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
+            const baseY = (unit.renderY ?? unit.y + 1) * this.CELL_SIZE;
+            const centerY = baseY - this.CELL_SIZE / 2;
+
             if (unit.sprite) {
                 if (unit.team === 'enemy') {
                     this.ctx.save();
-                    this.ctx.translate(drawX, drawY);
+                    this.ctx.translate(baseX, baseY);
                     this.ctx.scale(-1, 1);
-                    this.ctx.drawImage(unit.sprite, -this.CELL_SIZE / 2, -this.CELL_SIZE / 2, this.CELL_SIZE, this.CELL_SIZE);
+                    this.ctx.drawImage(unit.sprite, -this.CELL_SIZE / 2, -this.CELL_SIZE, this.CELL_SIZE, this.CELL_SIZE);
                     this.ctx.restore();
                 } else {
-                    this.ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE / 2, drawY - this.CELL_SIZE / 2, this.CELL_SIZE, this.CELL_SIZE);
+                    this.ctx.drawImage(unit.sprite, baseX - this.CELL_SIZE / 2, baseY - this.CELL_SIZE, this.CELL_SIZE, this.CELL_SIZE);
                 }
             } else {
                 this.ctx.font = '24px sans-serif';
                 this.ctx.textAlign = 'center';
                 this.ctx.textBaseline = 'middle';
-                this.ctx.fillText(unit.icon, drawX, drawY);
+                this.ctx.fillText(unit.icon, baseX, centerY);
             }
+
             this.ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
             this.ctx.beginPath();
-            this.ctx.arc(drawX, drawY + 15, 5, 0, 2 * Math.PI);
+            this.ctx.arc(baseX, centerY + 15, 5, 0, 2 * Math.PI);
             this.ctx.fill();
+
             const barWidth = this.CELL_SIZE * 0.8;
             const hpRatio = unit.hp / unit.maxHp;
             this.ctx.fillStyle = '#555';
-            this.ctx.fillRect(drawX - barWidth / 2, drawY - 20, barWidth, 5);
+            this.ctx.fillRect(baseX - barWidth / 2, centerY - 20, barWidth, 5);
             this.ctx.fillStyle = 'green';
-            this.ctx.fillRect(drawX - barWidth / 2, drawY - 20, barWidth * hpRatio, 5);
+            this.ctx.fillRect(baseX - barWidth / 2, centerY - 20, barWidth * hpRatio, 5);
             if (unit.maxShield > 0) {
                 const shieldRatio = unit.shield / unit.maxShield;
                 this.ctx.fillStyle = '#555';
-                this.ctx.fillRect(drawX - barWidth / 2, drawY - 26, barWidth, 5);
+                this.ctx.fillRect(baseX - barWidth / 2, centerY - 26, barWidth, 5);
                 this.ctx.fillStyle = 'cyan';
-                this.ctx.fillRect(drawX - barWidth / 2, drawY - 26, barWidth * shieldRatio, 5);
+                this.ctx.fillRect(baseX - barWidth / 2, centerY - 26, barWidth * shieldRatio, 5);
             }
-            this.combatManager.managers.vfxManager.drawStatusIcons(this.ctx, unit);
+
+            this.combatManager.managers.vfxManager.drawStatusIcons(this.ctx, unit, baseX, centerY);
         });
     }
 

--- a/js/managers/VisualEffectManager.js
+++ b/js/managers/VisualEffectManager.js
@@ -14,7 +14,7 @@ export class VisualEffectManager {
             text,
             color,
             x: target.x * this.cellSize + this.cellSize / 2,
-            y: target.y * this.cellSize,
+            y: (target.y + 0.5) * this.cellSize,
             duration: 60,
         });
     }
@@ -31,14 +31,15 @@ export class VisualEffectManager {
         });
     }
 
-    drawStatusIcons(ctx, unit) {
+    drawStatusIcons(ctx, unit, baseX = null, centerY = null) {
         const statuses = Object.keys(unit.statusEffects);
         if (statuses.length === 0) return;
-        const startX = unit.x * this.cellSize + (this.cellSize - statuses.length * 12) / 2;
+        const startX = (baseX ?? (unit.x * this.cellSize + this.cellSize / 2)) - (statuses.length * 12) / 2;
+        const drawY = (centerY ?? ((unit.y + 0.5) * this.cellSize)) - this.cellSize / 2 - 10;
         statuses.forEach((statusName, i) => {
             const icon = this.getStatusIcon(statusName);
             ctx.font = '12px sans-serif';
-            ctx.fillText(icon, startX + i * 12, unit.y * this.cellSize - 10);
+            ctx.fillText(icon, startX + i * 12, drawY);
         });
     }
 


### PR DESCRIPTION
## Summary
- adjust unit drawing to anchor sprites on tile bottom
- sort units vertically so sprites overlap by Y
- update status icon and popup positioning to work with new Y mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867f7801540832795b98b61e3189441