### PR TITLE
Fix responsive log area

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,10 +13,16 @@ h1 {
     text-shadow: 2px 2px 4px rgba(0,0,0,.5);
 }
 
+/* 게임 화면을 감싸는 컨테이너 */
+#game-wrapper {
+    display: inline-block; /* 내부 요소(canvas)의 너비에 맞춰 크기를 조정 */
+}
+
 canvas {
     background-color: #34495e;
     border: 3px solid #7f8c8d;
     border-radius: 10px;
+    display: block; /* wrapper를 꽉 채우도록 표시 */
 }
 
 #controls {
@@ -39,7 +45,8 @@ button:hover {
 }
 
 #log {
-    width: 2880px;
+    width: 100%;
+    box-sizing: border-box;
     height: 100px;
     background: rgba(0,0,0,.3);
     border-radius: 5px;

--- a/index.html
+++ b/index.html
@@ -7,9 +7,11 @@
 </head>
 <body>
     <h1>Covenant - 전투 시뮬레이션</h1>
-    <canvas id="gameCanvas" width="2880" height="1920"></canvas>
-    <div id="controls"><button id="startBtn">시뮬레이션 시작</button></div>
-    <div id="log"></div>
+    <div id="game-wrapper">
+        <canvas id="gameCanvas" width="2880" height="1920"></canvas>
+        <div id="controls"><button id="startBtn">시뮬레이션 시작</button></div>
+        <div id="log"></div>
+    </div>
 
     <script type="module" src="js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- wrap game canvas and log with `#game-wrapper`
- keep log width responsive to the canvas
- add a container style and ensure the canvas fills it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68689c4d90ec8327a6a614ae7e64d0ab