### PR TITLE
Implement binding manager with unit flags

### DIFF
--- a/js/combatManager.js
+++ b/js/combatManager.js
@@ -4,6 +4,9 @@
 import { Unit } from './unit.js'; // 's' 제거
 import { UNIT_TEMPLATES } from './data.js';
 
+const FLAG_OFFSET_X = -86;
+const FLAG_OFFSET_Y = -20;
+
 export class CombatManager {
     constructor(managers, uiControls) {
         this.managers = managers; // log, vfx, event, statusEffect 매니저 포함
@@ -51,6 +54,10 @@ export class CombatManager {
         this.allUnits = [...this.playerUnits, ...this.enemyUnits];
 
         this.managers.battleMaster.prepareBattle(this.allUnits, this.battleContext, this.managers.logManager);
+        const bm = this.managers.bindingManager;
+        bm.clear();
+        this.playerUnits.forEach(u => bm.bind(u, 'assets/images/blue-flag.png', FLAG_OFFSET_X, FLAG_OFFSET_Y, true));
+        this.enemyUnits.forEach(u => bm.bind(u, 'assets/images/red-flag.png', FLAG_OFFSET_X, FLAG_OFFSET_Y, true));
         this.allUnits.forEach(unit => unit.registerTriggers());
 
         this.managers.logManager.add("--- 전투 시작! 패시브 스킬 발동 ---");
@@ -71,11 +78,14 @@ export class CombatManager {
         this.init();
         if (this.managers.imageManager) {
             const units = this.allUnits;
-            const promises = units.map(u =>
-                this.managers.imageManager.load(u.image).then(img => {
-                    u.sprite = img;
-                })
-            );
+            const promises = [];
+            units.forEach(u => {
+                promises.push(this.managers.imageManager.load(u.image).then(img => { u.sprite = img; }));
+                const attachments = this.managers.bindingManager.get(u);
+                attachments.forEach(att => {
+                    promises.push(this.managers.imageManager.load(att.path).then(img => { att.img = img; }));
+                });
+            });
             await Promise.all(promises);
         }
         this.runTurn(); // 최초 턴 실행

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ import {
     DelayManager,
     AnimationManager,
     ImageManager,
+    BindingManager,
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
@@ -28,8 +29,9 @@ const aiManager = new AiManager(metaAiManager);
 const delayManager = new DelayManager();
 const animationManager = new AnimationManager(delayManager);
 const imageManager = new ImageManager();
+const bindingManager = new BindingManager();
 
-const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster, aiManager, metaAiManager, delayManager, animationManager, imageManager };
+const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster, aiManager, metaAiManager, delayManager, animationManager, imageManager, bindingManager };
 const uiControls = { startBtn };
 
 const simulationManager = new SimulationManager(allManagers, uiControls);

--- a/js/managers/BindingManager.js
+++ b/js/managers/BindingManager.js
@@ -1,0 +1,20 @@
+export class BindingManager {
+    constructor() {
+        this.bindings = new Map(); // unit -> array of attachments
+    }
+
+    bind(unit, path, offsetX = 0, offsetY = 0, behind = false) {
+        if (!this.bindings.has(unit)) {
+            this.bindings.set(unit, []);
+        }
+        this.bindings.get(unit).push({ path, img: null, offsetX, offsetY, behind });
+    }
+
+    get(unit) {
+        return this.bindings.get(unit) || [];
+    }
+
+    clear() {
+        this.bindings.clear();
+    }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -45,6 +45,16 @@ export class SimulationManager {
             const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
             const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE - 24;
 
+            const attachments = this.combatManager.managers.bindingManager.get(unit);
+            attachments.filter(a => a.behind).forEach(att => {
+                if (!att.img) {
+                    att.img = this.imageManager.get(att.path);
+                }
+                if (att.img) {
+                    ctx.drawImage(att.img, drawX + att.offsetX, drawY + att.offsetY);
+                }
+            });
+
             if (unit.sprite) {
                 const spriteHeight = this.CELL_SIZE;
 
@@ -63,6 +73,15 @@ export class SimulationManager {
                 ctx.textBaseline = 'middle';
                 ctx.fillText(unit.icon, drawX, drawY);
             }
+
+            attachments.filter(a => !a.behind).forEach(att => {
+                if (!att.img) {
+                    att.img = this.imageManager.get(att.path);
+                }
+                if (att.img) {
+                    ctx.drawImage(att.img, drawX + att.offsetX, drawY + att.offsetY);
+                }
+            });
 
             ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
             ctx.beginPath();
@@ -102,7 +121,14 @@ export class SimulationManager {
 
     loadUnitSprites() {
         const units = this.combatManager.allUnits;
-        const promises = units.map(u => this.imageManager.load(u.image).then(img => { u.sprite = img; }));
+        const promises = [];
+        units.forEach(u => {
+            promises.push(this.imageManager.load(u.image).then(img => { u.sprite = img; }));
+            const attachments = this.combatManager.managers.bindingManager.get(u);
+            attachments.forEach(att => {
+                promises.push(this.imageManager.load(att.path).then(img => { att.img = img; }));
+            });
+        });
         return Promise.all(promises);
     }
 

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -10,3 +10,4 @@ export { DelayManager } from './DelayManager.js';
 export { AnimationManager } from './AnimationManager.js';
 export { ImageManager } from './ImageManager.js';
 export { LayerManager } from './LayerManager.js';
+export { BindingManager } from './BindingManager.js';


### PR DESCRIPTION
## Summary
- introduce a `BindingManager` for attaching images to units
- render bound images before/after unit sprites
- load bound image assets with unit sprites
- attach blue or red flag to each unit to indicate team

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868a0df868483279d8b300d70d50786