### PR TITLE
Add background manager

### DIFF
--- a/battlefield_sample.html
+++ b/battlefield_sample.html
@@ -55,6 +55,9 @@
             margin: 20px auto;
             padding: 20px;
             background: rgba(0,0,0,0.2);
+            background-image: url('assets/images/battle-stage-forest.png');
+            background-size: cover;
+            background-position: center;
             border-radius: 15px;
             border: 3px solid #3498db;
         }
@@ -165,6 +168,9 @@
                 grid-template-columns: repeat(15, 134px);
                 grid-template-rows: repeat(10, 134px);
                 gap: 1px;
+                background-image: url('assets/images/battle-stage-forest.png');
+                background-size: cover;
+                background-position: center;
             }
             
             .grid-cell {

--- a/js/managers/BackgroundManager.js
+++ b/js/managers/BackgroundManager.js
@@ -1,0 +1,24 @@
+export class BackgroundManager {
+    constructor(imageManager, layerManager, width, height) {
+        this.imageManager = imageManager;
+        this.layerManager = layerManager;
+        this.width = width;
+        this.height = height;
+        this.ctx = this.layerManager.addLayer('background');
+        this.backgroundImg = null;
+    }
+
+    load(path) {
+        return this.imageManager.load(path).then(img => {
+            this.backgroundImg = img;
+            this.draw();
+        });
+    }
+
+    draw() {
+        this.ctx.clearRect(0, 0, this.width, this.height);
+        if (this.backgroundImg) {
+            this.ctx.drawImage(this.backgroundImg, 0, 0, this.width, this.height);
+        }
+    }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -1,5 +1,6 @@
 import { CombatManager } from '../combatManager.js';
 import { LayerManager } from './LayerManager.js';
+import { BackgroundManager } from './BackgroundManager.js';
 
 export class SimulationManager {
     constructor(managers, uiControls) {
@@ -14,11 +15,13 @@ export class SimulationManager {
         this.imageManager = managers.imageManager;
 
         this.layerManager = new LayerManager(this.canvas.width, this.canvas.height);
-        this.backgroundCtx = this.layerManager.addLayer('background');
+        this.backgroundManager = new BackgroundManager(this.imageManager, this.layerManager, this.canvas.width, this.canvas.height);
+        this.backgroundCtx = this.layerManager.getLayer('background');
         this.unitCtx = this.layerManager.addLayer('units');
     }
 
     preRenderGrid() {
+        this.backgroundManager.draw();
         this.backgroundCtx.strokeStyle = '#7f8c8d';
         this.backgroundCtx.lineWidth = 1;
         for (let i = 0; i <= this.GRID_COLS; i++) {
@@ -133,6 +136,7 @@ export class SimulationManager {
     }
 
     async init() {
+        await this.backgroundManager.load('assets/images/battle-stage-forest.png');
         this.preRenderGrid();
         this.combatManager.init();
         await this.loadUnitSprites();

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -11,3 +11,4 @@ export { AnimationManager } from './AnimationManager.js';
 export { ImageManager } from './ImageManager.js';
 export { LayerManager } from './LayerManager.js';
 export { BindingManager } from './BindingManager.js';
+export { BackgroundManager } from './BackgroundManager.js';


### PR DESCRIPTION
## Summary
- move battle stage background logic into a new `BackgroundManager`
- update `SimulationManager` to use the new manager
- export `BackgroundManager` for easy access

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a299dff0832785aef703a24fccc2