### PR TITLE
Add binding and decoration managers

### DIFF
--- a/js/combatManager.js
+++ b/js/combatManager.js
@@ -23,6 +23,9 @@ export class CombatManager {
     // 게임 초기화
     init() {
         this.managers.logManager.clear();
+        if (this.managers.bindingManager) {
+            this.managers.bindingManager.clear();
+        }
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;
@@ -77,6 +80,9 @@ export class CombatManager {
                 })
             );
             await Promise.all(promises);
+        }
+        if (this.managers.decorationManager) {
+            await this.managers.decorationManager.applyDefaultDecorations(this.allUnits);
         }
         this.runTurn(); // 최초 턴 실행
 

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,8 @@ import {
     DelayManager,
     AnimationManager,
     ImageManager,
+    BindingManager,
+    DecorationManager,
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
@@ -28,8 +30,23 @@ const aiManager = new AiManager(metaAiManager);
 const delayManager = new DelayManager();
 const animationManager = new AnimationManager(delayManager);
 const imageManager = new ImageManager();
+const bindingManager = new BindingManager(imageManager);
+const decorationManager = new DecorationManager(bindingManager);
 
-const allManagers = { logManager, vfxManager, eventManager, statusEffectManager, battleMaster, aiManager, metaAiManager, delayManager, animationManager, imageManager };
+const allManagers = {
+  logManager,
+  vfxManager,
+  eventManager,
+  statusEffectManager,
+  battleMaster,
+  aiManager,
+  metaAiManager,
+  delayManager,
+  animationManager,
+  imageManager,
+  bindingManager,
+  decorationManager,
+};
 const uiControls = { startBtn };
 
 const simulationManager = new SimulationManager(allManagers, uiControls);

--- a/js/managers/BindingManager.js
+++ b/js/managers/BindingManager.js
@@ -1,0 +1,21 @@
+export class BindingManager {
+  constructor(imageManager) {
+    this.imageManager = imageManager;
+    this.bindings = new Map(); // unitId -> [binding]
+  }
+
+  async bindImage(unit, path, offsetX = 0, offsetY = 0, behind = true) {
+    const img = await this.imageManager.load(path);
+    const arr = this.bindings.get(unit.id) || [];
+    arr.push({ img, offsetX, offsetY, behind });
+    this.bindings.set(unit.id, arr);
+  }
+
+  getBindings(unit) {
+    return this.bindings.get(unit.id) || [];
+  }
+
+  clear() {
+    this.bindings.clear();
+  }
+}

--- a/js/managers/DecorationManager.js
+++ b/js/managers/DecorationManager.js
@@ -1,0 +1,21 @@
+export class DecorationManager {
+  constructor(bindingManager, cellSize = 192) {
+    this.bindingManager = bindingManager;
+    this.cellSize = cellSize;
+  }
+
+  async applyFlag(unit) {
+    const flagPath =
+      unit.team === 'player'
+        ? 'assets/images/blue-flag.png'
+        : 'assets/images/red-flag.png';
+    const offsetX = -this.cellSize * 0.45;
+    const offsetY = -this.cellSize * 0.25;
+    await this.bindingManager.bindImage(unit, flagPath, offsetX, offsetY, true);
+  }
+
+  async applyDefaultDecorations(units) {
+    const promises = units.map((u) => this.applyFlag(u));
+    await Promise.all(promises);
+  }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -13,6 +13,7 @@ export class SimulationManager {
         this.GRID_ROWS = 10;
 
         this.imageManager = managers.imageManager;
+        this.bindingManager = managers.bindingManager;
 
         this.layerManager = new LayerManager(this.canvas.width, this.canvas.height);
         this.backgroundManager = new BackgroundManager(this.imageManager, this.layerManager, this.canvas.width, this.canvas.height);
@@ -47,10 +48,16 @@ export class SimulationManager {
         sorted.forEach(unit => {
             const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
             const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE - 24;
+            const spriteHeight = this.CELL_SIZE;
+            const topLeftX = drawX - this.CELL_SIZE / 2;
+            const topLeftY = drawY - spriteHeight;
+
+            const bindings = this.bindingManager ? this.bindingManager.getBindings(unit) : [];
+            bindings.filter(b => b.behind).forEach(b => {
+                ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY);
+            });
 
             if (unit.sprite) {
-                const spriteHeight = this.CELL_SIZE;
-
                 if (unit.team === 'enemy') {
                     ctx.save();
                     ctx.translate(drawX, drawY);
@@ -66,6 +73,10 @@ export class SimulationManager {
                 ctx.textBaseline = 'middle';
                 ctx.fillText(unit.icon, drawX, drawY);
             }
+
+            bindings.filter(b => !b.behind).forEach(b => {
+                ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY);
+            });
 
             ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
             ctx.beginPath();

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -12,3 +12,4 @@ export { ImageManager } from './ImageManager.js';
 export { LayerManager } from './LayerManager.js';
 export { BindingManager } from './BindingManager.js';
 export { BackgroundManager } from './BackgroundManager.js';
+export { DecorationManager } from './DecorationManager.js';


### PR DESCRIPTION
## Summary
- implement `BindingManager` to track images bound to units
- implement `DecorationManager` for team flags
- hook new managers into `CombatManager` and `SimulationManager`
- extend `main.js` to initialise new managers
- export new managers from manager index

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a788cd848327bbd17faae7db05f4