### PR TITLE
Fix manager initialization

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -52,6 +52,12 @@ const uiControls = { startBtn };
 const simulationManager = new SimulationManager(allManagers, uiControls);
 vfxManager.setCellSize(simulationManager.CELL_SIZE);
 
-window.onload = () => {
+function start() {
     simulationManager.init();
-};
+}
+
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    start();
+} else {
+    window.addEventListener('DOMContentLoaded', start);
+}


### PR DESCRIPTION
## Summary
- ensure manager initialization runs whether or not `window.onload` fires

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868a8fc668483278fa5c555f0b4224d