### PR TITLE
Scale down flag decorations

### DIFF
--- a/js/managers/BindingManager.js
+++ b/js/managers/BindingManager.js
@@ -4,10 +4,10 @@ export class BindingManager {
     this.bindings = new Map(); // unitId -> [binding]
   }
 
-  async bindImage(unit, path, offsetX = 0, offsetY = 0, behind = true) {
+  async bindImage(unit, path, offsetX = 0, offsetY = 0, behind = true, width = null, height = null) {
     const img = await this.imageManager.load(path);
     const arr = this.bindings.get(unit.id) || [];
-    arr.push({ img, offsetX, offsetY, behind });
+    arr.push({ img, offsetX, offsetY, behind, width, height });
     this.bindings.set(unit.id, arr);
   }
 

--- a/js/managers/DecorationManager.js
+++ b/js/managers/DecorationManager.js
@@ -11,7 +11,8 @@ export class DecorationManager {
         : 'assets/images/red-flag.png';
     const offsetX = -this.cellSize * 0.45;
     const offsetY = -this.cellSize * 0.25;
-    await this.bindingManager.bindImage(unit, flagPath, offsetX, offsetY, true);
+    const size = this.cellSize / 1.5; // shrink flag to roughly quarter original
+    await this.bindingManager.bindImage(unit, flagPath, offsetX, offsetY, true, size, size);
   }
 
   async applyDefaultDecorations(units) {

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -54,7 +54,9 @@ export class SimulationManager {
 
             const bindings = this.bindingManager ? this.bindingManager.getBindings(unit) : [];
             bindings.filter(b => b.behind).forEach(b => {
-                ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY);
+                const w = b.width || b.img.width;
+                const h = b.height || b.img.height;
+                ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY, w, h);
             });
 
             if (unit.sprite) {
@@ -75,7 +77,9 @@ export class SimulationManager {
             }
 
             bindings.filter(b => !b.behind).forEach(b => {
-                ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY);
+                const w = b.width || b.img.width;
+                const h = b.height || b.img.height;
+                ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY, w, h);
             });
 
             ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';


### PR DESCRIPTION
## Summary
- allow bound images to specify width and height
- render bound images with optional dimensions
- shrink ally/enemy flag decorations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ab62b1e88327839d85b18df9afbe