### PR TITLE
Add camera controls and larger units

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,7 @@ import {
     ImageManager,
     BindingManager,
     DecorationManager,
+    InputManager,
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
@@ -50,6 +51,8 @@ const allManagers = {
 const uiControls = { startBtn };
 
 const simulationManager = new SimulationManager(allManagers, uiControls);
+const inputManager = new InputManager(simulationManager.canvas);
+simulationManager.setInputManager(inputManager);
 vfxManager.setCellSize(simulationManager.CELL_SIZE);
 
 function start() {

--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -1,0 +1,40 @@
+export class InputManager {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.scale = 1;
+        this.offsetX = 0;
+        this.offsetY = 0;
+        this.isDragging = false;
+        this.lastX = 0;
+        this.lastY = 0;
+        this.minScale = 0.5;
+        this.maxScale = 2.5;
+        this._initEvents();
+    }
+
+    _initEvents() {
+        this.canvas.addEventListener('wheel', e => {
+            e.preventDefault();
+            const zoomFactor = 1 + (e.deltaY < 0 ? 0.1 : -0.1);
+            const newScale = this.scale * zoomFactor;
+            this.scale = Math.min(this.maxScale, Math.max(this.minScale, newScale));
+        });
+
+        const startDrag = e => {
+            this.isDragging = true;
+            this.lastX = e.clientX - this.offsetX;
+            this.lastY = e.clientY - this.offsetY;
+        };
+        const duringDrag = e => {
+            if (!this.isDragging) return;
+            this.offsetX = e.clientX - this.lastX;
+            this.offsetY = e.clientY - this.lastY;
+        };
+        const endDrag = () => { this.isDragging = false; };
+
+        this.canvas.addEventListener('pointerdown', startDrag);
+        window.addEventListener('pointermove', duringDrag);
+        window.addEventListener('pointerup', endDrag);
+        window.addEventListener('pointerleave', endDrag);
+    }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -1,9 +1,10 @@
 import { CombatManager } from '../combatManager.js';
 import { LayerManager } from './LayerManager.js';
 import { BackgroundManager } from './BackgroundManager.js';
+import { InputManager } from './InputManager.js';
 
 export class SimulationManager {
-    constructor(managers, uiControls) {
+    constructor(managers, uiControls, inputManager = null) {
         this.combatManager = new CombatManager(managers, uiControls);
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
@@ -19,6 +20,12 @@ export class SimulationManager {
         this.backgroundManager = new BackgroundManager(this.imageManager, this.layerManager, this.canvas.width, this.canvas.height);
         this.backgroundCtx = this.layerManager.getLayer('background');
         this.unitCtx = this.layerManager.addLayer('units');
+
+        this.inputManager = inputManager || new InputManager(this.canvas);
+    }
+
+    setInputManager(manager) {
+        this.inputManager = manager;
     }
 
     preRenderGrid() {
@@ -48,8 +55,8 @@ export class SimulationManager {
         sorted.forEach(unit => {
             const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
             const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE - 24;
-            const spriteHeight = this.CELL_SIZE;
-            const topLeftX = drawX - this.CELL_SIZE / 2;
+            const spriteHeight = this.CELL_SIZE * 2;
+            const topLeftX = drawX - this.CELL_SIZE;
             const topLeftY = drawY - spriteHeight;
 
             const bindings = this.bindingManager ? this.bindingManager.getBindings(unit) : [];
@@ -64,10 +71,10 @@ export class SimulationManager {
                     ctx.save();
                     ctx.translate(drawX, drawY);
                     ctx.scale(-1, 1);
-                    ctx.drawImage(unit.sprite, -this.CELL_SIZE / 2, -spriteHeight, this.CELL_SIZE, spriteHeight);
+                    ctx.drawImage(unit.sprite, -this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
                     ctx.restore();
                 } else {
-                    ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE / 2, drawY - spriteHeight, this.CELL_SIZE, spriteHeight);
+                    ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE, drawY - spriteHeight, this.CELL_SIZE * 2, spriteHeight);
                 }
             } else {
                 ctx.font = '24px sans-serif';
@@ -88,7 +95,7 @@ export class SimulationManager {
             ctx.fill();
 
             const barWidth = this.CELL_SIZE * 0.8;
-            const barYOffset = drawY - this.CELL_SIZE + 10;
+            const barYOffset = drawY - spriteHeight + 10;
             const hpRatio = unit.hp / unit.maxHp;
 
             ctx.fillStyle = '#555';
@@ -114,8 +121,14 @@ export class SimulationManager {
             this.drawUnits(units);
         }
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.save();
+        if (this.inputManager) {
+            this.ctx.translate(this.inputManager.offsetX, this.inputManager.offsetY);
+            this.ctx.scale(this.inputManager.scale, this.inputManager.scale);
+        }
         this.layerManager.draw(this.ctx);
         this.combatManager.managers.vfxManager.draw(this.ctx);
+        this.ctx.restore();
     }
 
     loadUnitSprites() {

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -13,3 +13,4 @@ export { LayerManager } from './LayerManager.js';
 export { BindingManager } from './BindingManager.js';
 export { BackgroundManager } from './BackgroundManager.js';
 export { DecorationManager } from './DecorationManager.js';
+export { InputManager } from './InputManager.js';


### PR DESCRIPTION
## Summary
- create new `InputManager` for handling zoom and drag on the canvas
- integrate `InputManager` with `SimulationManager` and `main.js`
- support camera transforms during rendering
- draw unit sprites at double height/width and reposition HP bars

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869099a832083278ef52c96fbbb0363