### PR TITLE
Add stretched shadow effect for units

### DIFF
--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -48,6 +48,7 @@ export class SimulationManager {
 
     drawUnits(units) {
         const ctx = this.unitCtx;
+        // Y좌표 기준으로 유닛들을 정렬합니다 (y가 작은 순서대로).
         const sorted = units
             .filter(u => !u.isDead)
             .sort((a, b) => a.y - b.y);
@@ -55,8 +56,8 @@ export class SimulationManager {
         sorted.forEach(unit => {
             const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
             const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE - 24;
-            const spriteHeight = this.CELL_SIZE * 2;
-            const topLeftX = drawX - this.CELL_SIZE;
+            const spriteHeight = this.CELL_SIZE;
+            const topLeftX = drawX - this.CELL_SIZE / 2;
             const topLeftY = drawY - spriteHeight;
 
             const bindings = this.bindingManager ? this.bindingManager.getBindings(unit) : [];
@@ -67,14 +68,29 @@ export class SimulationManager {
             });
 
             if (unit.sprite) {
+                // --- \uD83C\uDFA8 \uADF8\uB9B0\uC790 \uADF8\uB9B0\uAE30 \uC2DC\uC791 ---
+                ctx.save();
+                ctx.translate(drawX, drawY);
+                ctx.transform(1, 0, -0.5, 0.5, 0, 0);
+                if (unit.team === 'enemy') {
+                    ctx.scale(-1, 1);
+                }
+                ctx.globalAlpha = 0.6;
+                ctx.drawImage(unit.sprite, -this.CELL_SIZE / 2, -spriteHeight, this.CELL_SIZE, spriteHeight);
+                ctx.globalCompositeOperation = 'source-in';
+                ctx.fillStyle = 'black';
+                ctx.fillRect(-this.CELL_SIZE / 2, -spriteHeight, this.CELL_SIZE, spriteHeight);
+                ctx.restore();
+                // --- \uADF8\uB9B0\uC790 \uADF8\uB9B0\uAE30 \uC885\uB8CC ---
+
                 if (unit.team === 'enemy') {
                     ctx.save();
                     ctx.translate(drawX, drawY);
                     ctx.scale(-1, 1);
-                    ctx.drawImage(unit.sprite, -this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
+                    ctx.drawImage(unit.sprite, -this.CELL_SIZE / 2, -spriteHeight, this.CELL_SIZE, spriteHeight);
                     ctx.restore();
                 } else {
-                    ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE, drawY - spriteHeight, this.CELL_SIZE * 2, spriteHeight);
+                    ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE / 2, drawY - spriteHeight, this.CELL_SIZE, spriteHeight);
                 }
             } else {
                 ctx.font = '24px sans-serif';


### PR DESCRIPTION
## Summary
- update `SimulationManager.drawUnits` to render long dynamic shadows for units
- adjust sprite dimensions to match shadow transform

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68690af8310c8327b1fc9eb5c4e3ff23