### PR TITLE
Improve canvas pixel clarity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,12 @@ canvas {
     border: 3px solid #7f8c8d;
     border-radius: 10px;
     display: block; /* wrapper를 꽉 채우도록 표시 */
+
+    /* 이미지를 확대/축소하더라도 픽셀이 선명하게 보이도록 설정 */
+    image-rendering: -moz-crisp-edges;    /* Firefox */
+    image-rendering: -webkit-crisp-edges; /* WebKit */
+    image-rendering: pixelated;           /* 최신 브라우저 */
+    image-rendering: crisp-edges;         /* 구형 브라우저 호환 */
 }
 
 #controls {

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -8,6 +8,8 @@ export class SimulationManager {
         this.combatManager = new CombatManager(managers, uiControls);
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
+        // 캔버스 스케일 조정 시 이미지를 부드럽게 처리하지 않도록 설정
+        this.ctx.imageSmoothingEnabled = false;
         this.startBtn = uiControls.startBtn;
         this.CELL_SIZE = 192;
         this.GRID_COLS = 15;
@@ -20,6 +22,8 @@ export class SimulationManager {
         this.backgroundManager = new BackgroundManager(this.imageManager, this.layerManager, this.canvas.width, this.canvas.height);
         this.backgroundCtx = this.layerManager.getLayer('background');
         this.unitCtx = this.layerManager.addLayer('units');
+        this.backgroundCtx.imageSmoothingEnabled = false;
+        this.unitCtx.imageSmoothingEnabled = false;
 
         this.inputManager = inputManager || new InputManager(this.canvas);
     }


### PR DESCRIPTION
## Summary
- keep canvas pixels crisp when scaled via CSS `image-rendering`
- disable smoothing on all canvas contexts in `SimulationManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68690dfb4b708327881c29bbcf791f92