### PR TITLE
Disable shadow effects due to rendering bug

### DIFF
--- a/battlefield_sample.html
+++ b/battlefield_sample.html
@@ -181,7 +181,7 @@
         }
     </style>
 </head>
-<body>
+<body class="no-shadow">
     <div class="game-container">
         <h1>⚔️ 12vs12 전략 배틀 ⚔️</h1>
         

--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,18 @@ h1 {
     text-shadow: 2px 2px 4px rgba(0,0,0,.5);
 }
 
+/*
+ * Global shadow toggle
+ * A recent bug in browsers causes unexpected artifacting when shadows
+ * are enabled. Adding this override ensures shadows are disabled across
+ * the UI until the issue is resolved.
+ */
+body.no-shadow, body.no-shadow * {
+    text-shadow: none !important;
+    box-shadow: none !important;
+    filter: none !important;
+}
+
 /* 게임 화면을 감싸는 컨테이너 */
 #game-wrapper {
     display: inline-block; /* 내부 요소(canvas)의 너비에 맞춰 크기를 조정 */

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Covenant - 전투 시뮬레이션 (모듈화)</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="no-shadow">
     <h1>Covenant - 전투 시뮬레이션</h1>
     <div id="game-wrapper">
         <canvas id="gameCanvas" width="2880" height="1920"></canvas>

--- a/mercenary_territory_ui_sample.html
+++ b/mercenary_territory_ui_sample.html
@@ -511,7 +511,7 @@
         }
     </style>
 </head>
-<body>
+<body class="no-shadow">
     <!-- 상단 네비게이션 -->
     <div id="nav-bar">
         <button class="nav-button active" onclick="showScreen('mercenary')">👥 용병 고용</button>

--- a/world_mab_sample.html
+++ b/world_mab_sample.html
@@ -196,7 +196,7 @@
         }
     </style>
 </head>
-<body>
+<body class="no-shadow">
     <h1>던전 크롤러</h1>
     <div class="game-container">
         <div class="dungeon" id="dungeon"></div>


### PR DESCRIPTION
## Summary
- add CSS override to disable all shadow effects when `.no-shadow` is present
- apply `.no-shadow` class to sample HTML pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68696e2598708327a429d11121a15085