### PR TITLE
Disable team flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ CombatEngine: 자동 전투 로직 담당
 
 StatSystem: 스탯별 효과 계산기 (용맹, 무게 포함)
 
+DecorationManager: 유닛 장식 관리 (팀 깃발은 기본 비활성화, 필요시 `setFlagsEnabled(true)` 호출)
+
 📆 4. 개발 일정 예시 (가볍게)
 단계	목표	예상 기간
 v0.1 프로토타입	7vs7 전투 구현 + 스탯 영향 테스트	1~2주

--- a/js/managers/DecorationManager.js
+++ b/js/managers/DecorationManager.js
@@ -2,9 +2,15 @@ export class DecorationManager {
   constructor(bindingManager, cellSize = 192) {
     this.bindingManager = bindingManager;
     this.cellSize = cellSize;
+    this.flagsEnabled = false;
+  }
+
+  setFlagsEnabled(enabled) {
+    this.flagsEnabled = enabled;
   }
 
   async applyFlag(unit) {
+    if (!this.flagsEnabled) return;
     const flagPath =
       unit.team === 'player'
         ? 'assets/images/blue-flag.png'


### PR DESCRIPTION
## Summary
- add `flagsEnabled` toggle in `DecorationManager`
- skip flag bindings by default
- document the change in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a63d008648327b2381025b316c828