### PR TITLE
Add render and game loop managers

### DIFF
--- a/js/combatManager.js
+++ b/js/combatManager.js
@@ -1,7 +1,7 @@
 // [전투 총괄 매니저 파일]
 // 이 파일은 게임의 모든 전투 흐름을 관리하는 CombatManager 클래스를 정의합니다.
 
-import { Unit } from './unit.js'; // 's' 제거
+import { Unit } from './unit.js';
 import { UNIT_TEMPLATES } from './data.js';
 
 export class CombatManager {
@@ -11,8 +11,6 @@ export class CombatManager {
         this.playerUnits = [];
         this.enemyUnits = [];
         this.allUnits = [];
-        this.isSimulationRunning = false;
-        this.animationFrameId = null;
 
         this.battleContext = {
             weather: '맑음',
@@ -25,10 +23,6 @@ export class CombatManager {
         this.managers.logManager.clear();
         if (this.managers.bindingManager) {
             this.managers.bindingManager.clear();
-        }
-        if (this.animationFrameId) {
-            cancelAnimationFrame(this.animationFrameId);
-            this.animationFrameId = null;
         }
 
         const playerTemplates = [
@@ -43,12 +37,12 @@ export class CombatManager {
         this.playerUnits = playerTemplates.map((key, i) => {
             const x = Math.floor(i / 5);
             const y = (i % 5) * 2;
-            return new Unit(UNIT_TEMPLATES[key], "player", x, y, this.managers);
+            return new Unit(UNIT_TEMPLATES[key], 'player', x, y, this.managers);
         });
         this.enemyUnits = enemyTemplates.map((key, i) => {
             const x = (15 - 1) - Math.floor(i / 5);
             const y = (i % 5) * 2;
-            return new Unit(UNIT_TEMPLATES[key], "enemy", x, y, this.managers);
+            return new Unit(UNIT_TEMPLATES[key], 'enemy', x, y, this.managers);
         });
 
         this.allUnits = [...this.playerUnits, ...this.enemyUnits];
@@ -56,97 +50,27 @@ export class CombatManager {
         this.managers.battleMaster.prepareBattle(this.allUnits, this.battleContext, this.managers.logManager);
         this.allUnits.forEach(unit => unit.registerTriggers());
 
-        this.managers.logManager.add("--- 전투 시작! 패시브 스킬 발동 ---");
+        this.managers.logManager.add('--- 전투 시작! 패시브 스킬 발동 ---');
         this.allUnits.forEach(t => t.applyPassiveSkills());
         this.managers.logManager.flush();
 
         this.managers.logManager.clear();
-        this.managers.logManager.add("전투 준비 완료. 시뮬레이션 시작 버튼을 누르세요.");
+        this.managers.logManager.add('전투 준비 완료. 시뮬레이션 시작 버튼을 누르세요.');
         this.managers.logManager.flush();
     }
 
-    // 시뮬레이션 시작
-    async startSimulation(renderCallback) {
-        if (this.isSimulationRunning) return;
-        this.isSimulationRunning = true;
-        this.ui.startBtn.disabled = true;
-
-        this.init();
-        if (this.managers.imageManager) {
-            const units = this.allUnits;
-            const promises = units.map(u =>
-                this.managers.imageManager.load(u.image).then(img => {
-                    u.sprite = img;
-                })
-            );
-            await Promise.all(promises);
-        }
-        if (this.managers.decorationManager) {
-            await this.managers.decorationManager.applyDefaultDecorations(this.allUnits);
-        }
-        this.runTurn(); // 최초 턴 실행
-
-        const loop = () => {
-            if (!this.isSimulationRunning) return;
-            renderCallback(this.allUnits);
-            this.animationFrameId = requestAnimationFrame(loop);
-        };
-        this.animationFrameId = requestAnimationFrame(loop);
-    }
-
-    // 시뮬레이션 중지
-    stopSimulation() {
-        this.isSimulationRunning = false;
-        this.ui.startBtn.disabled = false;
-        if (this.animationFrameId) {
-            cancelAnimationFrame(this.animationFrameId);
-            this.animationFrameId = null;
-        }
-    }
-
-    // 턴 실행
-    async runTurn() {
-        if (!this.isSimulationRunning) return; // 중간에 중지되면 더 이상 진행하지 않음
-
-        this.managers.logManager.add("--- 새로운 턴 시작 ---");
-        const turnOrder = this.allUnits.filter(u => !u.isDead).sort((a, b) => a.weight - b.weight);
-        // 모든 유닛의 행동 여부를 새 턴마다 초기화합니다.
-        turnOrder.forEach(u => (u.hasActed = false));
-
-        for (const unit of turnOrder) {
-            if (unit.isDead || !this.isSimulationRunning) continue;
-            const enemies = unit.team === 'player' ? this.enemyUnits.filter(u => !u.isDead) : this.playerUnits.filter(u => !u.isDead);
-            const allies = unit.team === 'player' ? this.playerUnits.filter(u => !u.isDead) : this.enemyUnits.filter(u => !u.isDead);
-            unit.takeTurn(enemies, allies);
-            this.managers.logManager.flush();
-            if (this.managers.animationManager) {
-                await this.managers.animationManager.playQueuedMovements();
-            }
-            await this.managers.delayManager.wait(100);
-        }
-
-        if (!this.isSimulationRunning) return;
-
-        this.managers.logManager.add("--- 모든 유닛 행동 종료 ---");
-        this.managers.statusEffectManager.updateTurn();
-        this.managers.logManager.flush();
-
+    // 게임 종료 조건 확인
+    checkGameOver() {
         if (this.playerUnits.every(u => u.isDead)) {
-            this.managers.logManager.add("패배!", 'death');
-            this.stopSimulation();
-            return;
+            this.managers.logManager.add('패배!', 'death');
+            this.managers.logManager.flush();
+            return true;
         }
         if (this.enemyUnits.every(u => u.isDead)) {
-            this.managers.logManager.add("승리!", 'death');
-            this.stopSimulation();
-            return;
+            this.managers.logManager.add('승리!', 'death');
+            this.managers.logManager.flush();
+            return true;
         }
-
-        // 다음 턴 호출
-        setTimeout(() => this.runTurn(), 500);
-    }
-
-    sleep(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return false;
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -16,12 +16,16 @@ import {
     BindingManager,
     DecorationManager,
     InputManager,
+    // 새로운 매니저들
+    RenderLoopManager,
+    GameLoopManager
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
 const startBtn = document.getElementById('startBtn');
+const uiControls = { startBtn };
 
-// --- 매니저 인스턴스 생성 ---
+// --- 매니저 인스턴스 생성 (1단계: 기본 매니저) ---
 const logManager = new BattleLogManager(document.getElementById('log'));
 const vfxManager = new VisualEffectManager();
 const eventManager = new EventManager();
@@ -35,30 +39,38 @@ const bindingManager = new BindingManager(imageManager);
 const decorationManager = new DecorationManager(bindingManager);
 
 const allManagers = {
-  logManager,
-  vfxManager,
-  eventManager,
-  statusEffectManager,
-  battleMaster,
-  aiManager,
-  metaAiManager,
-  delayManager,
-  animationManager,
-  imageManager,
-  bindingManager,
-  decorationManager,
+  logManager, vfxManager, eventManager, statusEffectManager, battleMaster,
+  aiManager, metaAiManager, delayManager, animationManager, imageManager,
+  bindingManager, decorationManager,
 };
-const uiControls = { startBtn };
 
+// --- 매니저 인스턴스 생성 (2단계: 시뮬레이션 및 루프 매니저) ---
 const simulationManager = new SimulationManager(allManagers, uiControls);
 const inputManager = new InputManager(simulationManager.canvas);
 simulationManager.setInputManager(inputManager);
 vfxManager.setCellSize(simulationManager.CELL_SIZE);
 
-function start() {
-    simulationManager.init();
+// 루프 매니저 생성 및 연결
+const renderLoopManager = new RenderLoopManager(simulationManager);
+const gameLoopManager = new GameLoopManager(simulationManager.combatManager, delayManager);
+
+// --- 게임 시작 함수 ---
+async function start() {
+    // 1. 시뮬레이션 환경 초기화 (유닛 생성, 배경 로드 등)
+    await simulationManager.init();
+
+    // 2. 렌더링 루프 시작
+    renderLoopManager.start();
+
+    // 3. "시작" 버튼 클릭 시 게임 로직 루프 시작
+    startBtn.addEventListener('click', () => {
+        startBtn.disabled = true;
+        simulationManager.combatManager.init();
+        gameLoopManager.start();
+    });
 }
 
+// --- DOM 로드 후 게임 실행 ---
 if (document.readyState === 'complete' || document.readyState === 'interactive') {
     start();
 } else {

--- a/js/managers/GameLoopManager.js
+++ b/js/managers/GameLoopManager.js
@@ -1,0 +1,72 @@
+// --- 게임 상태 엔진: 게임의 흐름을 정의 ---
+const GameState = {
+    STOPPED: 'STOPPED',      // 정지
+    RUNNING: 'RUNNING',      // 턴 진행 중
+    TURN_ENDED: 'TURN_ENDED',// 턴 종료
+    GAME_OVER: 'GAME_OVER'   // 게임 종료
+};
+// ------------------------------------------
+
+export class GameLoopManager {
+    constructor(combatManager, delayManager) {
+        this.combatManager = combatManager;
+        this.delayManager = delayManager;
+        this.state = GameState.STOPPED;
+    }
+
+    async _loop() {
+        if (this.state !== GameState.RUNNING) return;
+
+        // 1. 새로운 턴 시작
+        this.combatManager.managers.logManager.add("--- 새로운 턴 시작 ---");
+        const turnOrder = this.combatManager.allUnits.filter(u => !u.isDead).sort((a, b) => a.weight - b.weight);
+        turnOrder.forEach(u => (u.hasActed = false));
+
+        // 2. 유닛 행동 실행
+        for (const unit of turnOrder) {
+            if (unit.isDead || this.state !== GameState.RUNNING) continue;
+            
+            const enemies = unit.team === 'player' ? this.combatManager.enemyUnits.filter(u => !u.isDead) : this.combatManager.playerUnits.filter(u => !u.isDead);
+            const allies = unit.team === 'player' ? this.combatManager.playerUnits.filter(u => !u.isDead) : this.combatManager.enemyUnits.filter(u => !u.isDead);
+            
+            unit.takeTurn(enemies, allies);
+            this.combatManager.managers.logManager.flush();
+
+            if (this.combatManager.managers.animationManager) {
+                await this.combatManager.managers.animationManager.playQueuedMovements();
+            }
+            await this.delayManager.wait(100);
+        }
+
+        if (this.state !== GameState.RUNNING) return;
+
+        // 3. 턴 종료 처리
+        this.state = GameState.TURN_ENDED;
+        this.combatManager.managers.logManager.add("--- 모든 유닛 행동 종료 ---");
+        this.combatManager.managers.statusEffectManager.updateTurn();
+        this.combatManager.managers.logManager.flush();
+        
+        // 4. 게임 종료 확인
+        if (this.combatManager.checkGameOver()) {
+            this.state = GameState.GAME_OVER;
+            this.stop();
+        } else {
+            // 5. 다음 턴 준비
+            this.state = GameState.RUNNING;
+            setTimeout(() => this._loop(), 500);
+        }
+    }
+
+    start() {
+        if (this.state !== GameState.STOPPED) return;
+        this.state = GameState.RUNNING;
+        console.log("⚔️ 게임 로직 루프 시작");
+        this._loop();
+    }
+
+    stop() {
+        console.log(`⚔️ 게임 로직 루프 정지 (상태: ${this.state})`);
+        this.state = GameState.STOPPED;
+        this.combatManager.ui.startBtn.disabled = false;
+    }
+}

--- a/js/managers/RenderLoopManager.js
+++ b/js/managers/RenderLoopManager.js
@@ -1,0 +1,47 @@
+export class RenderLoopManager {
+    constructor(simulationManager) {
+        this.simulationManager = simulationManager;
+        this.isRunning = false;
+        this.animationFrameId = null;
+
+        // --- 렌더링 엔진: FPS 추적 및 제어 ---
+        this.fps = 0;
+        this.frameCount = 0;
+        this.lastFpsUpdate = 0;
+        // ------------------------------------
+    }
+
+    _loop(timestamp) {
+        if (!this.isRunning) return;
+
+        // FPS 계산
+        this.frameCount++;
+        if (timestamp - this.lastFpsUpdate > 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFpsUpdate = timestamp;
+            // console.log(`FPS: ${this.fps}`); // FPS 확인용
+        }
+
+        this.simulationManager.render(this.simulationManager.combatManager.allUnits);
+        this.animationFrameId = requestAnimationFrame(this._loop.bind(this));
+    }
+
+    start() {
+        if (this.isRunning) return;
+        this.isRunning = true;
+        this.lastFpsUpdate = performance.now();
+        this.animationFrameId = requestAnimationFrame(this._loop.bind(this));
+        console.log("🎨 렌더링 루프 시작");
+    }
+
+    stop() {
+        if (!this.isRunning) return;
+        this.isRunning = false;
+        if (this.animationFrameId) {
+            cancelAnimationFrame(this.animationFrameId);
+            this.animationFrameId = null;
+        }
+        console.log("🎨 렌더링 루프 정지");
+    }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -8,9 +8,10 @@ export class SimulationManager {
         this.combatManager = new CombatManager(managers, uiControls);
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
-        // 캔버스 스케일 조정 시 이미지를 부드럽게 처리하지 않도록 설정
         this.ctx.imageSmoothingEnabled = false;
-        this.startBtn = uiControls.startBtn;
+        // startBtn 대신 uiControls 전체를 보존
+        this.ui = uiControls;
+        
         this.CELL_SIZE = 192;
         this.GRID_COLS = 15;
         this.GRID_ROWS = 10;
@@ -129,38 +130,28 @@ export class SimulationManager {
         this.combatManager.managers.vfxManager.drawStatusIcons(ctx, unit);
     }
 
+    // 렌더링 함수 (Y 좌표 기준 정렬)
     render(units) {
-        // 1. 유닛 레이어를 깨끗하게 지웁니다.
         this.unitCtx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
         if (units) {
-            // 2. 애니메이션 중인 Y좌표(renderY)까지 고려하여 유닛을 정렬합니다.
             const sorted = units.slice().sort((a, b) => {
                 const yA = a.renderY ?? a.y;
                 const yB = b.renderY ?? b.y;
                 return yA - yB;
             });
-
-            // 3. 정렬된 유닛을 하나씩 `unitCtx`에 그립니다.
             sorted.forEach(unit => {
                 this.drawUnit(unit, this.unitCtx);
             });
         }
 
-        // 4. 메인 캔버스를 지웁니다.
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
         this.ctx.save();
-
-        // 5. 화면 이동 및 확대/축소를 적용합니다.
         if (this.inputManager) {
             this.ctx.translate(this.inputManager.offsetX, this.inputManager.offsetY);
             this.ctx.scale(this.inputManager.scale, this.inputManager.scale);
         }
-        
-        // 6. 모든 레이어(배경, 유닛)를 메인 캔버스에 그립니다.
         this.layerManager.draw(this.ctx);
-        
-        // 7. 시각 효과(데미지 숫자 등)를 그립니다.
         this.combatManager.managers.vfxManager.draw(this.ctx);
         this.ctx.restore();
     }
@@ -183,15 +174,16 @@ export class SimulationManager {
         this.inputManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
     }
 
+    // 초기 세팅만 수행하고 루프는 외부에서 제어
     async init() {
         await this.backgroundManager.load('assets/images/battle-stage-forest.png');
         this.preRenderGrid();
         this.combatManager.init();
         await this.loadUnitSprites();
+        await this.combatManager.managers.decorationManager.applyDefaultDecorations(this.combatManager.allUnits);
         this.autoFit();
+
+        // 초기 렌더링
         this.render(this.combatManager.allUnits);
-        this.startBtn.addEventListener('click', async () => {
-            await this.combatManager.startSimulation(units => this.render(units));
-        });
     }
 }

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -14,3 +14,6 @@ export { BindingManager } from './BindingManager.js';
 export { BackgroundManager } from './BackgroundManager.js';
 export { DecorationManager } from './DecorationManager.js';
 export { InputManager } from './InputManager.js';
+// 추가된 매니저들
+export { RenderLoopManager } from './RenderLoopManager.js';
+export { GameLoopManager } from './GameLoopManager.js';


### PR DESCRIPTION
## Summary
- remove rendering logic from `SimulationManager`
- strip loop code from `CombatManager` and add `checkGameOver`
- create `RenderLoopManager` and `GameLoopManager`
- export new managers and wire them in `main.js`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686df80af3c8832786c45135c7e07f42