### PR TITLE
Enable interactions before battle

### DIFF
--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -1,6 +1,7 @@
 export class InputManager {
     constructor(canvas) {
         this.canvas = canvas;
+        this.canvas.style.touchAction = 'none';
         this.scale = 1;
         this.offsetX = 0;
         this.offsetY = 0;
@@ -9,7 +10,13 @@ export class InputManager {
         this.lastY = 0;
         this.minScale = 0.5;
         this.maxScale = 2.5;
+        this.initialized = false;
+    }
+
+    init() {
+        if (this.initialized) return;
         this._initEvents();
+        this.initialized = true;
     }
 
     _initEvents() {
@@ -18,7 +25,7 @@ export class InputManager {
             const zoomFactor = 1 + (e.deltaY < 0 ? 0.1 : -0.1);
             const newScale = this.scale * zoomFactor;
             this.scale = Math.min(this.maxScale, Math.max(this.minScale, newScale));
-        });
+        }, { passive: false });
 
         const startDrag = e => {
             this.isDragging = true;

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -183,6 +183,10 @@ export class SimulationManager {
         await this.combatManager.managers.decorationManager.applyDefaultDecorations(this.combatManager.allUnits);
         this.autoFit();
 
+        if (this.inputManager) {
+            this.inputManager.init();
+        }
+
         // 초기 렌더링
         this.render(this.combatManager.allUnits);
     }


### PR DESCRIPTION
## Summary
- delay InputManager event binding until SimulationManager initialization
- call InputManager.init during initialization so map dragging and zooming work before starting combat
- enable passive control on wheel events and disable default touch actions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686df95ff1e483279e19b7847b007bb5