### PR TITLE
Introduce RendererManager

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,15 +15,16 @@ import {
     ImageManager,
     BindingManager,
     DecorationManager,
-    InputManager,
     // 새로운 매니저들
     RenderLoopManager,
-    GameLoopManager
+    GameLoopManager,
+    RendererManager
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
 const startBtn = document.getElementById('startBtn');
 const uiControls = { startBtn };
+const canvas = document.getElementById('gameCanvas');
 
 // --- 매니저 인스턴스 생성 (1단계: 기본 매니저) ---
 const logManager = new BattleLogManager(document.getElementById('log'));
@@ -38,38 +39,35 @@ const imageManager = new ImageManager();
 const bindingManager = new BindingManager(imageManager);
 const decorationManager = new DecorationManager(bindingManager);
 
-const allManagers = {
+const baseManagers = {
   logManager, vfxManager, eventManager, statusEffectManager, battleMaster,
   aiManager, metaAiManager, delayManager, animationManager, imageManager,
   bindingManager, decorationManager,
 };
 
 // --- 매니저 인스턴스 생성 (2단계: 시뮬레이션 및 루프 매니저) ---
-const simulationManager = new SimulationManager(allManagers, uiControls);
-const inputManager = new InputManager(simulationManager.canvas);
-simulationManager.setInputManager(inputManager);
-vfxManager.setCellSize(simulationManager.CELL_SIZE);
+const simulationManager = new SimulationManager(baseManagers, uiControls);
 
-// 루프 매니저 생성 및 연결
-const renderLoopManager = new RenderLoopManager(simulationManager);
+// 렌더링 및 루프 전문 매니저 생성
+const rendererManager = new RendererManager(canvas, {
+    combatManager: simulationManager.combatManager,
+    layerManager: simulationManager.managers.layerManager,
+    inputManager: simulationManager.managers.inputManager
+});
+vfxManager.setCellSize(rendererManager.CELL_SIZE);
+
+const renderLoopManager = new RenderLoopManager(rendererManager);
 const gameLoopManager = new GameLoopManager(simulationManager.combatManager, delayManager);
 
 // --- 게임 시작 함수 ---
 async function start() {
-    // 1. 시뮬레이션 환경 초기화 (유닛 생성, 배경 로드 등)
     await simulationManager.init();
-
-    // 2. 렌더링 루프 시작
+    rendererManager.autoFit();
     renderLoopManager.start();
 
-    // 3. "시작" 버튼 클릭 시 게임 로직 루프 시작
-    startBtn.addEventListener('click', async () => {
+    startBtn.addEventListener('click', () => {
         startBtn.disabled = true;
         simulationManager.combatManager.init();
-        await simulationManager.loadUnitSprites();
-        await simulationManager.combatManager.managers.decorationManager.applyDefaultDecorations(
-            simulationManager.combatManager.allUnits
-        );
         gameLoopManager.start();
     });
 }

--- a/js/managers/RenderLoopManager.js
+++ b/js/managers/RenderLoopManager.js
@@ -1,6 +1,6 @@
 export class RenderLoopManager {
-    constructor(simulationManager) {
-        this.simulationManager = simulationManager;
+    constructor(rendererManager) {
+        this.rendererManager = rendererManager;
         this.isRunning = false;
         this.animationFrameId = null;
 
@@ -23,7 +23,7 @@ export class RenderLoopManager {
             // console.log(`FPS: ${this.fps}`); // FPS 확인용
         }
 
-        this.simulationManager.render(this.simulationManager.combatManager.allUnits);
+        this.rendererManager.render();
         this.animationFrameId = requestAnimationFrame(this._loop.bind(this));
     }
 

--- a/js/managers/RendererManager.js
+++ b/js/managers/RendererManager.js
@@ -1,0 +1,133 @@
+export class RendererManager {
+    constructor(canvas, managers) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+        this.combatManager = managers.combatManager; // CombatManager에 직접 접근
+        this.layerManager = managers.layerManager;
+        this.inputManager = managers.inputManager;
+
+        // --- 렌더링 엔진: 캔버스와 관련된 모든 요소를 소유 ---
+        this.CELL_SIZE = 192;
+        this.GRID_COLS = 15;
+        this.GRID_ROWS = 10;
+        this.unitCtx = this.layerManager.getLayer('units');
+        // ----------------------------------------------------
+    }
+
+    drawUnit(unit, ctx) {
+        if (unit.isDead) return;
+
+        const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
+        const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE - 24;
+        const spriteHeight = this.CELL_SIZE * 2;
+        const topLeftX = drawX - this.CELL_SIZE;
+        const topLeftY = drawY - spriteHeight;
+
+        const bindings = this.combatManager.managers.bindingManager.getBindings(unit) || [];
+        bindings.filter(b => b.behind).forEach(b => {
+            const w = b.width || b.img.width;
+            const h = b.height || b.img.height;
+            ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY, w, h);
+        });
+
+        if (unit.sprite) {
+            // --- 그림자 그리기 시작 ---
+            ctx.save();
+            ctx.translate(drawX, drawY);
+            ctx.transform(1, 0, -0.5, 0.5, 0, 0);
+            if (unit.team === 'enemy') {
+                ctx.scale(-1, 1);
+            }
+            ctx.globalAlpha = 0.6;
+            ctx.drawImage(unit.sprite, -this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
+            ctx.globalCompositeOperation = 'source-in';
+            ctx.fillStyle = 'black';
+            ctx.fillRect(-this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
+            ctx.restore();
+            // --- 그림자 그리기 종료 ---
+
+            if (unit.team === 'enemy') {
+                ctx.save();
+                ctx.translate(drawX, drawY);
+                ctx.scale(-1, 1);
+                ctx.drawImage(unit.sprite, -this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
+                ctx.restore();
+            } else {
+                ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE, drawY - spriteHeight, this.CELL_SIZE * 2, spriteHeight);
+            }
+        } else {
+            ctx.font = '24px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(unit.icon, drawX, drawY);
+        }
+
+        bindings.filter(b => !b.behind).forEach(b => {
+            const w = b.width || b.img.width;
+            const h = b.height || b.img.height;
+            ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY, w, h);
+        });
+
+        ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
+        ctx.beginPath();
+        ctx.arc(drawX, drawY + 15, 5, 0, 2 * Math.PI);
+        ctx.fill();
+
+        const barWidth = this.CELL_SIZE * 0.8;
+        const barYOffset = drawY - spriteHeight + 10;
+        const hpRatio = unit.hp / unit.maxHp;
+
+        ctx.fillStyle = '#555';
+        ctx.fillRect(drawX - barWidth / 2, barYOffset, barWidth, 5);
+        ctx.fillStyle = 'green';
+        ctx.fillRect(drawX - barWidth / 2, barYOffset, barWidth * hpRatio, 5);
+
+        if (unit.maxShield > 0) {
+            const shieldRatio = unit.shield / unit.maxShield;
+            ctx.fillStyle = '#555';
+            ctx.fillRect(drawX - barWidth / 2, barYOffset - 6, barWidth, 5);
+            ctx.fillStyle = 'cyan';
+            ctx.fillRect(drawX - barWidth / 2, barYOffset - 6, barWidth * shieldRatio, 5);
+        }
+
+        this.combatManager.managers.vfxManager.drawStatusIcons(ctx, unit);
+    }
+
+    render() {
+        const units = this.combatManager.allUnits;
+        this.unitCtx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+        if (units) {
+            const sorted = units.slice().sort((a, b) => {
+                const yA = a.renderY ?? a.y;
+                const yB = b.renderY ?? b.y;
+                return yA - yB;
+            });
+            sorted.forEach(unit => {
+                this.drawUnit(unit, this.unitCtx);
+            });
+        }
+
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.save();
+        if (this.inputManager) {
+            this.ctx.translate(this.inputManager.offsetX, this.inputManager.offsetY);
+            this.ctx.scale(this.inputManager.scale, this.inputManager.scale);
+        }
+        this.layerManager.draw(this.ctx);
+        this.combatManager.managers.vfxManager.draw(this.ctx);
+        this.ctx.restore();
+    }
+
+    autoFit() {
+        if (!this.inputManager) return;
+        const maxWidth = window.innerWidth;
+        const maxHeight = window.innerHeight;
+        const scaleX = maxWidth / (this.CELL_SIZE * this.GRID_COLS);
+        const scaleY = maxHeight / (this.CELL_SIZE * this.GRID_ROWS);
+        const scale = Math.min(scaleX, scaleY, 1);
+        this.inputManager.scale = scale;
+        this.inputManager.offsetX = (maxWidth - this.canvas.width * scale) / 2;
+        this.inputManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
+    }
+}

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -4,190 +4,54 @@ import { BackgroundManager } from './BackgroundManager.js';
 import { InputManager } from './InputManager.js';
 
 export class SimulationManager {
-    constructor(managers, uiControls, inputManager = null) {
+    constructor(managers, uiControls) {
         this.combatManager = new CombatManager(managers, uiControls);
         this.canvas = document.getElementById('gameCanvas');
-        this.ctx = this.canvas.getContext('2d');
-        this.ctx.imageSmoothingEnabled = false;
-        // startBtn 대신 uiControls 전체를 보존
-        this.ui = uiControls;
-        
-        this.CELL_SIZE = 192;
-        this.GRID_COLS = 15;
-        this.GRID_ROWS = 10;
 
-        this.imageManager = managers.imageManager;
-        this.bindingManager = managers.bindingManager;
+        // --- 엔진: 핵심 매니저들을 소유하고 연결 ---
+        this.managers = managers;
+        this.managers.layerManager = new LayerManager(this.canvas.width, this.canvas.height);
+        this.managers.inputManager = new InputManager(this.canvas);
+        this.backgroundManager = new BackgroundManager(this.managers.imageManager, this.managers.layerManager, this.canvas.width, this.canvas.height);
+        // ------------------------------------------
 
-        this.layerManager = new LayerManager(this.canvas.width, this.canvas.height);
-        this.backgroundManager = new BackgroundManager(this.imageManager, this.layerManager, this.canvas.width, this.canvas.height);
-        this.backgroundCtx = this.layerManager.getLayer('background');
-        this.unitCtx = this.layerManager.addLayer('units');
+        // 자잘한 설정
+        this.backgroundCtx = this.managers.layerManager.addLayer('background');
+        this.unitCtx = this.managers.layerManager.addLayer('units');
         this.backgroundCtx.imageSmoothingEnabled = false;
         this.unitCtx.imageSmoothingEnabled = false;
-
-        this.inputManager = inputManager || new InputManager(this.canvas);
     }
 
-    setInputManager(manager) {
-        this.inputManager = manager;
-    }
-
-    preRenderGrid() {
-        this.backgroundManager.draw();
-        this.backgroundCtx.strokeStyle = '#7f8c8d';
-        this.backgroundCtx.lineWidth = 1;
-        for (let i = 0; i <= this.GRID_COLS; i++) {
-            this.backgroundCtx.beginPath();
-            this.backgroundCtx.moveTo(i * this.CELL_SIZE, 0);
-            this.backgroundCtx.lineTo(i * this.CELL_SIZE, this.GRID_ROWS * this.CELL_SIZE);
-            this.backgroundCtx.stroke();
-        }
-        for (let i = 0; i <= this.GRID_ROWS; i++) {
-            this.backgroundCtx.beginPath();
-            this.backgroundCtx.moveTo(0, i * this.CELL_SIZE);
-            this.backgroundCtx.lineTo(this.GRID_COLS * this.CELL_SIZE, i * this.CELL_SIZE);
-            this.backgroundCtx.stroke();
-        }
-    }
-
-    drawUnit(unit, ctx) {
-        if (unit.isDead) return;
-
-        const drawX = (unit.renderX ?? unit.x) * this.CELL_SIZE + this.CELL_SIZE / 2;
-        const drawY = (unit.renderY ?? unit.y) * this.CELL_SIZE + this.CELL_SIZE - 24;
-        const spriteHeight = this.CELL_SIZE * 2;
-        const topLeftX = drawX - this.CELL_SIZE;
-        const topLeftY = drawY - spriteHeight;
-
-        const bindings = this.bindingManager ? this.bindingManager.getBindings(unit) : [];
-        bindings.filter(b => b.behind).forEach(b => {
-            const w = b.width || b.img.width;
-            const h = b.height || b.img.height;
-            ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY, w, h);
-        });
-
-        if (unit.sprite) {
-            // --- 그림자 그리기 시작 ---
-            ctx.save();
-            ctx.translate(drawX, drawY);
-            ctx.transform(1, 0, -0.5, 0.5, 0, 0);
-            if (unit.team === 'enemy') {
-                ctx.scale(-1, 1);
-            }
-            ctx.globalAlpha = 0.6;
-            ctx.drawImage(unit.sprite, -this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
-            ctx.globalCompositeOperation = 'source-in';
-            ctx.fillStyle = 'black';
-            ctx.fillRect(-this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
-            ctx.restore();
-            // --- 그림자 그리기 종료 ---
-
-            if (unit.team === 'enemy') {
-                ctx.save();
-                ctx.translate(drawX, drawY);
-                ctx.scale(-1, 1);
-                ctx.drawImage(unit.sprite, -this.CELL_SIZE, -spriteHeight, this.CELL_SIZE * 2, spriteHeight);
-                ctx.restore();
-            } else {
-                ctx.drawImage(unit.sprite, drawX - this.CELL_SIZE, drawY - spriteHeight, this.CELL_SIZE * 2, spriteHeight);
-            }
-        } else {
-            ctx.font = '24px sans-serif';
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText(unit.icon, drawX, drawY);
-        }
-
-        bindings.filter(b => !b.behind).forEach(b => {
-            const w = b.width || b.img.width;
-            const h = b.height || b.img.height;
-            ctx.drawImage(b.img, topLeftX + b.offsetX, topLeftY + b.offsetY, w, h);
-        });
-
-        ctx.fillStyle = unit.team === 'player' ? '#3498db' : '#e74c3c';
-        ctx.beginPath();
-        ctx.arc(drawX, drawY + 15, 5, 0, 2 * Math.PI);
-        ctx.fill();
-
-        const barWidth = this.CELL_SIZE * 0.8;
-        const barYOffset = drawY - spriteHeight + 10;
-        const hpRatio = unit.hp / unit.maxHp;
-
-        ctx.fillStyle = '#555';
-        ctx.fillRect(drawX - barWidth / 2, barYOffset, barWidth, 5);
-        ctx.fillStyle = 'green';
-        ctx.fillRect(drawX - barWidth / 2, barYOffset, barWidth * hpRatio, 5);
-
-        if (unit.maxShield > 0) {
-            const shieldRatio = unit.shield / unit.maxShield;
-            ctx.fillStyle = '#555';
-            ctx.fillRect(drawX - barWidth / 2, barYOffset - 6, barWidth, 5);
-            ctx.fillStyle = 'cyan';
-            ctx.fillRect(drawX - barWidth / 2, barYOffset - 6, barWidth * shieldRatio, 5);
-        }
-
-        this.combatManager.managers.vfxManager.drawStatusIcons(ctx, unit);
-    }
-
-    // 렌더링 함수 (Y 좌표 기준 정렬)
-    render(units) {
-        this.unitCtx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-
-        if (units) {
-            const sorted = units.slice().sort((a, b) => {
-                const yA = a.renderY ?? a.y;
-                const yB = b.renderY ?? b.y;
-                return yA - yB;
-            });
-            sorted.forEach(unit => {
-                this.drawUnit(unit, this.unitCtx);
-            });
-        }
-
-        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        this.ctx.save();
-        if (this.inputManager) {
-            this.ctx.translate(this.inputManager.offsetX, this.inputManager.offsetY);
-            this.ctx.scale(this.inputManager.scale, this.inputManager.scale);
-        }
-        this.layerManager.draw(this.ctx);
-        this.combatManager.managers.vfxManager.draw(this.ctx);
-        this.ctx.restore();
-    }
-
-    loadUnitSprites() {
-        const units = this.combatManager.allUnits;
-        const promises = units.map(u => this.imageManager.load(u.image).then(img => { u.sprite = img; }));
-        return Promise.all(promises);
-    }
-
-    autoFit() {
-        if (!this.inputManager) return;
-        const maxWidth = window.innerWidth;
-        const maxHeight = window.innerHeight;
-        const scaleX = maxWidth / (this.CELL_SIZE * this.GRID_COLS);
-        const scaleY = maxHeight / (this.CELL_SIZE * this.GRID_ROWS);
-        const scale = Math.min(scaleX, scaleY, 1);
-        this.inputManager.scale = scale;
-        this.inputManager.offsetX = (maxWidth - this.canvas.width * scale) / 2;
-        this.inputManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
-    }
-
-    // 초기 세팅만 수행하고 루프는 외부에서 제어
+    // [수정됨] init 함수는 이제 렌더링이 아닌 '데이터 준비'만 담당합니다.
     async init() {
         await this.backgroundManager.load('assets/images/battle-stage-forest.png');
         this.preRenderGrid();
         this.combatManager.init();
-        await this.loadUnitSprites();
+
+        // 유닛 스프라이트 로드
+        const units = this.combatManager.allUnits;
+        const promises = units.map(u => this.managers.imageManager.load(u.image).then(img => { u.sprite = img; }));
+        await Promise.all(promises);
+
         await this.combatManager.managers.decorationManager.applyDefaultDecorations(this.combatManager.allUnits);
-        this.autoFit();
 
-        if (this.inputManager) {
-            this.inputManager.init();
+        // 초기 렌더링은 이제 RendererManager와 RenderLoopManager가 담당
+    }
+
+    preRenderGrid() {
+        this.backgroundCtx.strokeStyle = '#7f8c8d';
+        this.backgroundCtx.lineWidth = 1;
+        for (let i = 0; i <= 15; i++) { // GRID_COLS
+            this.backgroundCtx.beginPath();
+            this.backgroundCtx.moveTo(i * 192, 0); // CELL_SIZE
+            this.backgroundCtx.lineTo(i * 192, 10 * 192); // GRID_ROWS * CELL_SIZE
+            this.backgroundCtx.stroke();
         }
-
-        // 초기 렌더링
-        this.render(this.combatManager.allUnits);
+        for (let i = 0; i <= 10; i++) { // GRID_ROWS
+            this.backgroundCtx.beginPath();
+            this.backgroundCtx.moveTo(0, i * 192);
+            this.backgroundCtx.lineTo(15 * 192, i * 192); // GRID_COLS * CELL_SIZE
+            this.backgroundCtx.stroke();
+        }
     }
 }

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -17,3 +17,4 @@ export { InputManager } from './InputManager.js';
 // 추가된 매니저들
 export { RenderLoopManager } from './RenderLoopManager.js';
 export { GameLoopManager } from './GameLoopManager.js';
+export { RendererManager } from './RendererManager.js';


### PR DESCRIPTION
## Summary
- add `RendererManager` to handle drawing of units and canvas scaling
- adjust `RenderLoopManager` to delegate drawing to the renderer
- simplify `SimulationManager` so init only sets up data
- wire new manager in `main.js`
- remove unused constructor arg in renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e031ce3688327ab410becb553f21c