### PR TITLE
Fix unit sprite reset on simulation start

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -65,9 +65,10 @@ async function start() {
     rendererManager.autoFit();
     renderLoopManager.start();
 
-    startBtn.addEventListener('click', () => {
+    startBtn.addEventListener('click', async () => {
         startBtn.disabled = true;
         simulationManager.combatManager.init();
+        await simulationManager.prepareUnits();
         gameLoopManager.start();
     });
 }

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -27,15 +27,19 @@ export class SimulationManager {
         await this.backgroundManager.load('assets/images/battle-stage-forest.png');
         this.preRenderGrid();
         this.combatManager.init();
-
-        // 유닛 스프라이트 로드
-        const units = this.combatManager.allUnits;
-        const promises = units.map(u => this.managers.imageManager.load(u.image).then(img => { u.sprite = img; }));
-        await Promise.all(promises);
-
-        await this.combatManager.managers.decorationManager.applyDefaultDecorations(this.combatManager.allUnits);
+        await this.prepareUnits();
 
         // 초기 렌더링은 이제 RendererManager와 RenderLoopManager가 담당
+    }
+
+    async prepareUnits() {
+        const units = this.combatManager.allUnits;
+        const promises = units.map(u =>
+            this.managers.imageManager.load(u.image).then(img => { u.sprite = img; })
+        );
+        await Promise.all(promises);
+
+        await this.combatManager.managers.decorationManager.applyDefaultDecorations(units);
     }
 
     preRenderGrid() {


### PR DESCRIPTION
## Summary
- ensure sprites reload when the combat manager reinitializes
- reload unit graphics when starting a new simulation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0929e9dc8327b42057bafdbdd3f0