### PR TITLE
Fix camera scaling and prevent panning beyond map

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,7 +15,9 @@ h1 {
 
 /* 게임 화면을 감싸는 컨테이너 */
 #game-wrapper {
-    display: inline-block; /* 내부 요소(canvas)의 너비에 맞춰 크기를 조정 */
+    display: block;
+    width: 100%;
+    overflow: hidden;
 }
 
 canvas {

--- a/js/main.js
+++ b/js/main.js
@@ -41,7 +41,11 @@ const imageManager = new ImageManager();
 const bindingManager = new BindingManager(imageManager);
 const decorationManager = new DecorationManager(bindingManager);
 const cameraManager = new CameraManager();
-const inputManager = new InputManager(canvas, cameraManager);
+const inputManager = new InputManager(
+  canvas,
+  cameraManager,
+  { width: 15 * 192, height: 10 * 192 }
+);
 inputManager.init();
 
 const baseManagers = {
@@ -68,6 +72,7 @@ const gameLoopManager = new GameLoopManager(simulationManager.combatManager, del
 async function start() {
     await simulationManager.init();
     rendererManager.autoFit();
+    window.addEventListener('resize', () => rendererManager.autoFit());
     renderLoopManager.start();
 
     startBtn.addEventListener('click', async () => {

--- a/js/managers/CameraManager.js
+++ b/js/managers/CameraManager.js
@@ -22,4 +22,13 @@ export class CameraManager {
         this.offsetX = 0;
         this.offsetY = 0;
     }
+
+    clampOffset(canvasW, canvasH, worldW, worldH) {
+        const scaledW = worldW * this.scale;
+        const scaledH = worldH * this.scale;
+        const minX = canvasW - scaledW;
+        const minY = canvasH - scaledH;
+        this.offsetX = Math.min(0, Math.max(minX, this.offsetX));
+        this.offsetY = Math.min(0, Math.max(minY, this.offsetY));
+    }
 }

--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -1,9 +1,11 @@
 import { CameraManager } from './CameraManager.js';
 
 export class InputManager {
-    constructor(canvas, cameraManager = new CameraManager()) {
+    constructor(canvas, cameraManager = new CameraManager(), bounds = {width: 0, height: 0}) {
         this.canvas = canvas;
         this.camera = cameraManager;
+        this.worldWidth = bounds.width;
+        this.worldHeight = bounds.height;
         this.canvas.style.touchAction = 'none';
         this.isDragging = false;
         this.lastX = 0;
@@ -22,6 +24,7 @@ export class InputManager {
             e.preventDefault();
             const zoomFactor = 1 + (e.deltaY < 0 ? 0.1 : -0.1);
             this.camera.zoom(zoomFactor);
+            this.camera.clampOffset(this.canvas.width, this.canvas.height, this.worldWidth, this.worldHeight);
         }, { passive: false });
 
         const startDrag = e => {
@@ -32,8 +35,12 @@ export class InputManager {
         const duringDrag = e => {
             if (!this.isDragging) return;
             this.camera.setOffset(e.clientX - this.lastX, e.clientY - this.lastY);
+            this.camera.clampOffset(this.canvas.width, this.canvas.height, this.worldWidth, this.worldHeight);
         };
-        const endDrag = () => { this.isDragging = false; };
+        const endDrag = () => {
+            this.isDragging = false;
+            this.camera.clampOffset(this.canvas.width, this.canvas.height, this.worldWidth, this.worldHeight);
+        };
 
         this.canvas.addEventListener('pointerdown', startDrag);
         window.addEventListener('pointermove', duringDrag);

--- a/js/managers/RendererManager.js
+++ b/js/managers/RendererManager.js
@@ -96,8 +96,8 @@ export class RendererManager {
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
         this.ctx.save();
         if (this.cameraManager) {
-            this.ctx.translate(this.cameraManager.offsetX, this.cameraManager.offsetY);
             this.ctx.scale(this.cameraManager.scale, this.cameraManager.scale);
+            this.ctx.translate(this.cameraManager.offsetX, this.cameraManager.offsetY);
         }
         this.layerManager.draw(this.ctx);
         this.combatManager.managers.vfxManager.draw(this.ctx);
@@ -114,5 +114,7 @@ export class RendererManager {
         this.cameraManager.scale = scale;
         this.cameraManager.offsetX = (maxWidth - this.canvas.width * scale) / 2;
         this.cameraManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
+        this.canvas.style.width = `${this.canvas.width * scale}px`;
+        this.canvas.style.height = `${this.canvas.height * scale}px`;
     }
 }

--- a/js/managers/SimulationManager.js
+++ b/js/managers/SimulationManager.js
@@ -13,7 +13,11 @@ export class SimulationManager {
         this.managers = managers;
         this.managers.layerManager = new LayerManager(this.canvas.width, this.canvas.height);
         this.managers.cameraManager = managers.cameraManager || new CameraManager();
-        this.managers.inputManager = managers.inputManager || new InputManager(this.canvas, this.managers.cameraManager);
+        this.managers.inputManager = managers.inputManager || new InputManager(
+            this.canvas,
+            this.managers.cameraManager,
+            { width: 15 * 192, height: 10 * 192 }
+        );
         this.managers.inputManager.init();
         this.backgroundManager = new BackgroundManager(this.managers.imageManager, this.managers.layerManager, this.canvas.width, this.canvas.height);
         // ------------------------------------------


### PR DESCRIPTION
## Summary
- ensure game wrapper scales to viewport
- adjust camera to clamp to map bounds and correct render transform order
- resize canvas via `autoFit` and handle window resize
- update input handling for zoom and drag with bounds

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1426d8788327a3f280990cf970b2