### PR TITLE
Add strike visual effect

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -6,6 +6,8 @@ import { VisualEffectManager } from './managers/VisualEffectManager.js';
 import { EventManager } from './managers/EventManager.js';
 import { StatusEffectManager } from './managers/StatusEffectManager.js';
 import { battleMaster } from './managers/BattleMaster.js';
+import { DelayManager } from './managers/DelayManager.js';
+import { ImageManager } from './managers/ImageManager.js';
 
 const canvas = document.getElementById('gameCanvas'), ctx = canvas.getContext('2d');
 const startBtn = document.getElementById('startBtn'), logElement = document.getElementById('log');
@@ -20,7 +22,9 @@ const backgroundCtx = backgroundCanvas.getContext('2d');
 
 const logManager = new BattleLogManager(document.getElementById('log'));
 // [시각효과] 전역에서 사용될 비주얼 이펙트 매니저 인스턴스
-const vfxManager = new VisualEffectManager();
+const delayManager = new DelayManager();
+const imageManager = new ImageManager();
+const vfxManager = new VisualEffectManager(delayManager, imageManager);
 
 
 // [총괄 매니저] 이번 전투에 적용될 외부 요인 (임시 데이터)

--- a/js/main.js
+++ b/js/main.js
@@ -30,14 +30,14 @@ const canvas = document.getElementById('gameCanvas');
 
 // --- 매니저 인스턴스 생성 (1단계: 기본 매니저) ---
 const logManager = new BattleLogManager(document.getElementById('log'));
-const vfxManager = new VisualEffectManager();
+const delayManager = new DelayManager();
+const imageManager = new ImageManager();
+const vfxManager = new VisualEffectManager(delayManager, imageManager);
 const eventManager = new EventManager();
 const statusEffectManager = new StatusEffectManager(logManager);
 const metaAiManager = new MetaAiManager();
 const aiManager = new AiManager(metaAiManager);
-const delayManager = new DelayManager();
 const animationManager = new AnimationManager(delayManager);
-const imageManager = new ImageManager();
 const bindingManager = new BindingManager(imageManager);
 const decorationManager = new DecorationManager(bindingManager);
 const cameraManager = new CameraManager();

--- a/js/managers/VisualEffectManager.js
+++ b/js/managers/VisualEffectManager.js
@@ -1,16 +1,47 @@
 export class VisualEffectManager {
-    constructor(cellSize = 50) {
+    constructor(delayManager, imageManager, cellSize = 50) {
         this.effects = [];
         this.cellSize = cellSize;
+        this.delayManager = delayManager;
+        this.imageManager = imageManager;
     }
 
     setCellSize(cellSize) {
         this.cellSize = cellSize;
     }
 
+    // 타격 이펙트 애니메이션 추가
+    addStrikeEffect(target) {
+        const animationPromise = new Promise(async (resolve) => {
+            const effectImages = [
+                'assets/images/strike-effect-1.png',
+                'assets/images/strike-effect-2.png'
+            ];
+            const imagePath = effectImages[Math.floor(Math.random() * effectImages.length)];
+            const image = await this.imageManager.load(imagePath);
+
+            const effect = {
+                id: (Math.random() + 1).toString(36).substring(7),
+                type: 'strike',
+                target,
+                image,
+                duration: 30,
+                maxDuration: 30,
+                scale: 0.5,
+                opacity: 1.0,
+            };
+            this.effects.push(effect);
+
+            setTimeout(resolve, effect.duration * (1000 / 60));
+        });
+
+        this.delayManager.waitFor(animationPromise);
+    }
+
     addPopup(text, target, color = 'white') {
         this.effects.push({
             id: (Math.random() + 1).toString(36).substring(7),
+            type: 'popup',
             text,
             color,
             x: target.x * this.cellSize + this.cellSize / 2,
@@ -21,11 +52,32 @@ export class VisualEffectManager {
 
     draw(ctx) {
         this.effects = this.effects.filter(effect => {
-            ctx.fillStyle = effect.color;
-            ctx.font = 'bold 16px sans-serif';
-            ctx.textAlign = 'center';
-            ctx.fillText(effect.text, effect.x, effect.y);
-            effect.y -= 0.5;
+            if (effect.type === 'strike') {
+                const { target, image, duration, maxDuration } = effect;
+                const progress = 1 - (duration / maxDuration);
+
+                effect.scale = 0.5 + progress * 1.5;
+                if (progress > 0.5) {
+                    effect.opacity = 1.0 - ((progress - 0.5) * 2);
+                }
+
+                const centerX = (target.renderX ?? target.x) * this.cellSize + this.cellSize / 2;
+                const centerY = (target.renderY ?? target.y) * this.cellSize + this.cellSize / 2;
+                const size = this.cellSize * effect.scale;
+
+                ctx.save();
+                ctx.globalAlpha = Math.max(0, effect.opacity);
+                ctx.drawImage(image, centerX - size / 2, centerY - size / 2, size, size);
+                ctx.restore();
+
+            } else if (effect.type === 'popup') {
+                ctx.fillStyle = effect.color;
+                ctx.font = 'bold 16px sans-serif';
+                ctx.textAlign = 'center';
+                ctx.fillText(effect.text, effect.x, effect.y);
+                effect.y -= 0.5;
+            }
+
             effect.duration--;
             return effect.duration > 0;
         });

--- a/js/unit.js
+++ b/js/unit.js
@@ -155,6 +155,7 @@ export class Unit {
     basicAttack(target) {
         const damage = this.getAttackPower();
         this.managers.logManager.add(`⚔️ ${this.name} → ${target.name} 일반 공격! (${damage} 피해)`, 'attack');
+        this.managers.vfxManager.addStrikeEffect(target);
         target.takeDamage(damage);
         this.managers.eventManager.publish('unitAttack', { caster: this, target: target, damage: damage });
     }

--- a/test/aiCombat.test.js
+++ b/test/aiCombat.test.js
@@ -9,7 +9,7 @@ const createManagers = () => {
     return {
         logManager: { add() {}, flush() {}, clear() {} },
         eventManager: { publish() {}, subscribe() {} },
-        vfxManager: { addPopup() {}, draw() {}, drawStatusIcons() {} },
+        vfxManager: { addPopup() {}, draw() {}, drawStatusIcons() {}, addStrikeEffect() {} },
         statusEffectManager: { register() {}, remove() {}, updateTurn() {} },
         battleMaster: {},
         aiManager: ai,


### PR DESCRIPTION
## Summary
- construct `VisualEffectManager` with DelayManager and ImageManager
- add strike animation effect that pauses the turn while it plays
- trigger strike effect on basic attacks
- adapt game.js and tests for new manager interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2bde60048327a82d88cf79406f4d