### PR TITLE
Implement hit shake effect for units

### DIFF
--- a/js/managers/VisualEffectManager.js
+++ b/js/managers/VisualEffectManager.js
@@ -1,6 +1,7 @@
 export class VisualEffectManager {
     constructor(delayManager, imageManager, cellSize = 50) {
         this.effects = [];
+        this.shakeEffects = []; // 피격 흔들림 효과 배열
         this.cellSize = cellSize;
         this.delayManager = delayManager;
         this.imageManager = imageManager;
@@ -50,7 +51,23 @@ export class VisualEffectManager {
         });
     }
 
+    // 피격 시 흔들림 효과 추가
+    addHitShakeEffect(target) {
+        const existing = this.shakeEffects.find(s => s.target.id === target.id);
+        if (existing) {
+            existing.duration = 10;
+            return;
+        }
+
+        this.shakeEffects.push({
+            target,
+            duration: 10,
+            amplitude: 2
+        });
+    }
+
     draw(ctx) {
+        // strike & popup 효과 처리
         this.effects = this.effects.filter(effect => {
             if (effect.type === 'strike') {
                 const { target, image, duration, maxDuration } = effect;
@@ -80,6 +97,21 @@ export class VisualEffectManager {
 
             effect.duration--;
             return effect.duration > 0;
+        });
+
+        // 피격 흔들림 효과 처리
+        this.shakeEffects = this.shakeEffects.filter(shake => {
+            const { target, duration, amplitude } = shake;
+            const renderX = target.renderX ?? target.x;
+            const renderY = target.renderY ?? target.y;
+            const actualX = renderX * this.cellSize;
+            const actualY = renderY * this.cellSize;
+            const offsetX = Math.sin(Date.now() * 20) * amplitude;
+
+            ctx.drawImage(target.image, actualX + offsetX, actualY, this.cellSize, this.cellSize);
+
+            shake.duration--;
+            return shake.duration > 0;
         });
     }
 

--- a/js/unit.js
+++ b/js/unit.js
@@ -116,6 +116,7 @@ export class Unit {
         
         // [수정] 전역 vfxManager 대신, 내장된 this.managers.vfxManager를 사용합니다.
         this.managers.vfxManager.addPopup(`-${finalDamage}`, this, '#ff4757');
+        this.managers.vfxManager.addHitShakeEffect(this);
 
         if (this.hp <= 0 && !this.isDead) {
             this.hp = 0;

--- a/test/aiCombat.test.js
+++ b/test/aiCombat.test.js
@@ -9,7 +9,7 @@ const createManagers = () => {
     return {
         logManager: { add() {}, flush() {}, clear() {} },
         eventManager: { publish() {}, subscribe() {} },
-        vfxManager: { addPopup() {}, draw() {}, drawStatusIcons() {}, addStrikeEffect() {} },
+        vfxManager: { addPopup() {}, draw() {}, drawStatusIcons() {}, addStrikeEffect() {}, addHitShakeEffect() {} },
         statusEffectManager: { register() {}, remove() {}, updateTurn() {} },
         battleMaster: {},
         aiManager: ai,


### PR DESCRIPTION
## Summary
- add shake effect array to `VisualEffectManager` and implement `addHitShakeEffect`
- render hit shake animation in `VisualEffectManager.draw`
- trigger shake effect when `Unit` takes damage
- adjust tests to stub new function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2fdf700083279a30729c6c799c31