### PR TITLE
Add world map UI and manager

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,3 +74,16 @@ button:hover {
 .log-skill { color: #3498db; }
 .log-heal { color: #2ecc71; }
 .log-death { font-weight: bold; color: #f1c40f; }
+
+#worldMap {
+    width: 100%;
+    height: 450px;
+    margin-top: 15px;
+    border: 1px solid #7f8c8d;
+}
+
+#worldMap iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         <canvas id="gameCanvas" width="2880" height="1920"></canvas>
         <div id="controls"><button id="startBtn">시뮬레이션 시작</button></div>
         <div id="log"></div>
+        <div id="worldMap"></div>
     </div>
 
     <script type="module" src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -20,13 +20,16 @@ import {
     // 새로운 매니저들
     RenderLoopManager,
     GameLoopManager,
-    RendererManager
+    RendererManager,
+    UiManager
 } from './managers/index.js';
 
 // --- 전역 변수 및 UI 요소 ---
 const startBtn = document.getElementById('startBtn');
 const uiControls = { startBtn };
 const canvas = document.getElementById('gameCanvas');
+const uiManager = new UiManager({ logElement: document.getElementById('log') });
+uiManager.initWorldMap();
 
 // --- 매니저 인스턴스 생성 (1단계: 기본 매니저) ---
 const logManager = new BattleLogManager(document.getElementById('log'));

--- a/js/managers/UiManager.js
+++ b/js/managers/UiManager.js
@@ -1,0 +1,23 @@
+export class UiManager {
+    constructor(options = {}) {
+        this.logElement = options.logElement || document.getElementById('log');
+        this.wrapper = options.wrapper || document.getElementById('game-wrapper');
+        this.worldMapUrl = options.worldMapUrl || 'world_mab_sample.html';
+        this.worldMap = null;
+    }
+
+    initWorldMap() {
+        if (this.worldMap) return;
+        const container = document.createElement('div');
+        container.id = 'worldMap';
+        const iframe = document.createElement('iframe');
+        iframe.src = this.worldMapUrl;
+        container.appendChild(iframe);
+        if (this.logElement) {
+            this.logElement.insertAdjacentElement('afterend', container);
+        } else {
+            this.wrapper.appendChild(container);
+        }
+        this.worldMap = container;
+    }
+}

--- a/js/managers/index.js
+++ b/js/managers/index.js
@@ -19,3 +19,4 @@ export { CameraManager } from './CameraManager.js';
 export { RenderLoopManager } from './RenderLoopManager.js';
 export { GameLoopManager } from './GameLoopManager.js';
 export { RendererManager } from './RendererManager.js';
+export { UiManager } from './UiManager.js';


### PR DESCRIPTION
## Summary
- add a placeholder container for a world map under the combat log
- style the new world map area
- create `UiManager` to insert the world map iframe
- wire the manager into the main script and export it

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f3992f788832798cbd4ec8f7645cb