### PR TITLE
Improve canvas centering and camera fit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,18 +15,22 @@ h1 {
 
 /* 게임 화면을 감싸는 컨테이너 */
 #game-wrapper {
-    display: block;
+    display: flex; /* flexbox 레이아웃으로 변경 */
+    justify-content: center; /* 가로 중앙 정렬 */
+    align-items: center; /* 세로 중앙 정렬 */
     width: 100%;
     overflow: hidden;
+    flex-grow: 1; /* 남은 공간을 모두 차지하도록 설정 */
 }
 
 canvas {
     background-color: #34495e;
     border: 3px solid #7f8c8d;
     border-radius: 10px;
-    display: block; /* wrapper를 꽉 채우도록 표시 */
-    width: 100%;
-    height: auto;
+    display: block;
+    /* width와 height는 autoFit이 제어하므로 제거 */
+    /* width: 100%; */
+    /* height: auto; */
 
     /* 이미지를 확대/축소하더라도 픽셀이 선명하게 보이도록 설정 */
     image-rendering: -moz-crisp-edges;    /* Firefox */

--- a/js/managers/RendererManager.js
+++ b/js/managers/RendererManager.js
@@ -106,14 +106,24 @@ export class RendererManager {
 
     autoFit() {
         if (!this.cameraManager) return;
-        const maxWidth = window.innerWidth;
-        const maxHeight = window.innerHeight;
+
+        // window.innerHeight 대신 body의 클라이언트 높이를 사용해 더 정확한 계산
+        const maxWidth = document.body.clientWidth;
+        const maxHeight = document.body.clientHeight;
+
         const scaleX = maxWidth / (this.CELL_SIZE * this.GRID_COLS);
         const scaleY = maxHeight / (this.CELL_SIZE * this.GRID_ROWS);
-        const scale = Math.min(scaleX, scaleY, 1);
+
+        // 0.95를 곱해 약간의 여백을 줍니다.
+        const scale = Math.min(scaleX, scaleY, 1) * 0.95;
+
+        // 카메라의 줌 레벨을 설정합니다.
         this.cameraManager.scale = scale;
-        this.cameraManager.offsetX = (maxWidth - this.canvas.width * scale) / 2;
-        this.cameraManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
+
+        // 카메라 위치를 초기화합니다.
+        this.cameraManager.setOffset(0, 0);
+
+        // 캔버스의 화면상 크기를 조절합니다.
         this.canvas.style.width = `${this.canvas.width * scale}px`;
         this.canvas.style.height = `${this.canvas.height * scale}px`;
     }


### PR DESCRIPTION
## Summary
- center the game canvas using flexbox
- let `autoFit` size the canvas and reset camera offsets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f900e334c8327ad4f5cecf293b7a7