### PR TITLE
Add attack lunge animation

### DIFF
--- a/js/managers/AnimationManager.js
+++ b/js/managers/AnimationManager.js
@@ -5,6 +5,21 @@ export class AnimationManager {
         this.moveQueue = [];
     }
 
+    // Attack lunge animation depending on team direction
+    queueAttackLunge(unit) {
+        const lungeDistance = 0.4;
+        const direction = unit.team === 'player' ? 1 : -1;
+
+        const originalX = unit.x;
+        const originalY = unit.y;
+        const lungeX = originalX + lungeDistance * direction;
+
+        // forward lunge
+        this.queueMovement(unit, originalX, originalY, lungeX, originalY);
+        // return to original position
+        this.queueMovement(unit, lungeX, originalY, originalX, originalY);
+    }
+
     queueMovement(unit, fromX, fromY, toX, toY) {
         this.moveQueue.push({ unit, fromX, fromY, toX, toY });
     }

--- a/js/unit.js
+++ b/js/unit.js
@@ -138,8 +138,12 @@ export class Unit {
             skill.effect(this, target, this.managers);
         }
     }
-    
+
     attemptSkillOrAttack(target) {
+        if (this.managers?.animationManager) {
+            this.managers.animationManager.queueAttackLunge(this);
+        }
+
         let didUseSkill = false;
         for (const skillKey of this.skills) {
             const skill = SKILLS[skillKey];


### PR DESCRIPTION
## Summary
- add `queueAttackLunge` helper in `AnimationManager`
- trigger lunge animation before every skill or attack in `Unit`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f9155147c832794d4728c28f4ee98