### PR TITLE
Fix map scaling and centering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,7 +6,7 @@ body {
     flex-direction: column;
     align-items: center;
     margin: 0;
-    padding: 20px;
+    padding: 0;
 }
 
 h1 {

--- a/js/managers/RendererManager.js
+++ b/js/managers/RendererManager.js
@@ -96,8 +96,9 @@ export class RendererManager {
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
         this.ctx.save();
         if (this.cameraManager) {
-            this.ctx.scale(this.cameraManager.scale, this.cameraManager.scale);
+            // translate first so offset is not affected by scaling
             this.ctx.translate(this.cameraManager.offsetX, this.cameraManager.offsetY);
+            this.ctx.scale(this.cameraManager.scale, this.cameraManager.scale);
         }
         this.layerManager.draw(this.ctx);
         this.combatManager.managers.vfxManager.draw(this.ctx);
@@ -110,10 +111,15 @@ export class RendererManager {
         const maxHeight = window.innerHeight;
         const scaleX = maxWidth / (this.CELL_SIZE * this.GRID_COLS);
         const scaleY = maxHeight / (this.CELL_SIZE * this.GRID_ROWS);
-        const scale = Math.min(scaleX, scaleY, 1);
+
+        // 가장 큰 비율을 사용해 화면을 가득 채우되 비율을 유지한다
+        const scale = Math.min(scaleX, scaleY);
         this.cameraManager.scale = scale;
-        this.cameraManager.offsetX = (maxWidth - this.canvas.width * scale) / 2;
-        this.cameraManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
+
+        // 스케일 적용 전 기준에서 중심 오프셋을 계산한다
+        this.cameraManager.offsetX = (maxWidth / scale - this.canvas.width) / 2;
+        this.cameraManager.offsetY = (maxHeight / scale - this.canvas.height) / 2;
+
         this.canvas.style.width = `${this.canvas.width * scale}px`;
         this.canvas.style.height = `${this.canvas.height * scale}px`;
     }


### PR DESCRIPTION
## Summary
- ensure body has no padding so the canvas can fill the page
- translate before scaling and adjust autofit logic to properly center and scale the map

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9a818d008327a3238beef2bf2096