### PR TITLE
Fix map zoom limits

### DIFF
--- a/js/managers/CameraManager.js
+++ b/js/managers/CameraManager.js
@@ -3,7 +3,7 @@ export class CameraManager {
         this.scale = 1;
         this.offsetX = 0;
         this.offsetY = 0;
-        this.minScale = 0.5;
+        this.minScale = 1;
         this.maxScale = 2.5;
     }
 

--- a/js/managers/RendererManager.js
+++ b/js/managers/RendererManager.js
@@ -112,6 +112,7 @@ export class RendererManager {
         const scaleY = maxHeight / (this.CELL_SIZE * this.GRID_ROWS);
         const scale = Math.min(scaleX, scaleY, 1);
         this.cameraManager.scale = scale;
+        this.cameraManager.minScale = scale;
         this.cameraManager.offsetX = (maxWidth - this.canvas.width * scale) / 2;
         this.cameraManager.offsetY = (maxHeight - this.canvas.height * scale) / 2;
         this.canvas.style.width = `${this.canvas.width * scale}px`;


### PR DESCRIPTION
## Summary
- keep camera zoom from going below the map frame
- update autoFit to sync the minimum scale with current fit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870bdf6b9448327aba2022cac25e1e7