### PR TITLE
Improve canvas sizing and dungeon camera

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,8 +25,8 @@ canvas {
     border: 3px solid #7f8c8d;
     border-radius: 10px;
     display: block; /* wrapper를 꽉 채우도록 표시 */
-    width: 100%;
-    height: auto;
+    width: 2880px;
+    height: 1920px;
 
     /* 이미지를 확대/축소하더라도 픽셀이 선명하게 보이도록 설정 */
     image-rendering: -moz-crisp-edges;    /* Firefox */

--- a/world_mab_sample.html
+++ b/world_mab_sample.html
@@ -25,8 +25,8 @@
         }
         .dungeon {
             display: grid;
-            grid-template-columns: repeat(10, 192px);
-            grid-template-rows: repeat(10, 192px);
+            grid-template-columns: repeat(var(--view-size, 10), 192px);
+            grid-template-rows: repeat(var(--view-size, 10), 192px);
             gap: 2px;
             background-color: #333;
             padding: 10px;
@@ -435,6 +435,9 @@
             dungeonSize: 10
         };
 
+        // 화면에 표시할 맵 범위 (항상 홀수 값 권장)
+        const VIEW_SIZE = 9;
+
         // 아이템 생성 함수
         function createItem(itemKey, x, y) {
             const itemData = ITEMS[itemKey];
@@ -775,23 +778,33 @@
         function renderDungeon() {
             const dungeonElement = document.getElementById('dungeon');
             dungeonElement.innerHTML = '';
-            
-            for (let y = 0; y < gameState.dungeonSize; y++) {
-                for (let x = 0; x < gameState.dungeonSize; x++) {
+
+            const half = Math.floor(VIEW_SIZE / 2);
+            const offsetX = Math.max(0, Math.min(gameState.dungeonSize - VIEW_SIZE, gameState.player.x - half));
+            const offsetY = Math.max(0, Math.min(gameState.dungeonSize - VIEW_SIZE, gameState.player.y - half));
+
+            dungeonElement.style.setProperty('--view-size', VIEW_SIZE);
+            dungeonElement.style.gridTemplateColumns = `repeat(${VIEW_SIZE}, 192px)`;
+            dungeonElement.style.gridTemplateRows = `repeat(${VIEW_SIZE}, 192px)`;
+
+            for (let y = 0; y < VIEW_SIZE; y++) {
+                for (let x = 0; x < VIEW_SIZE; x++) {
+                    const mapX = offsetX + x;
+                    const mapY = offsetY + y;
                     const cell = document.createElement('div');
                     cell.className = 'cell';
-                    
+
                     // 시야에 가려진 영역
-                    if (gameState.fogOfWar[y][x]) {
+                    if (gameState.fogOfWar[mapY][mapX]) {
                         cell.classList.add('fog');
                     } else {
                         // 플레이어 위치
-                        if (x === gameState.player.x && y === gameState.player.y) {
+                        if (mapX === gameState.player.x && mapY === gameState.player.y) {
                             cell.classList.add('player');
                             cell.textContent = '@';
                         } else {
                             // 다른 던전 요소들
-                            const cellType = gameState.dungeon[y][x];
+                            const cellType = gameState.dungeon[mapY][mapX];
                             cell.classList.add(cellType);
                             
                             switch (cellType) {
@@ -800,7 +813,7 @@
                                     break;
                                 case 'monster':
                                     // 몬스터 타입에 따른 아이콘과 색상
-                                    const monster = gameState.monsters.find(m => m.x === x && m.y === y);
+                                    const monster = gameState.monsters.find(m => m.x === mapX && m.y === mapY);
                                     if (monster) {
                                         cell.textContent = monster.icon;
                                         cell.style.color = monster.color;


### PR DESCRIPTION
## Summary
- align canvas HTML size with CSS by fixing width/height
- allow dungeon grid size to change via CSS variable
- add `VIEW_SIZE` constant and center dungeon rendering around the player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870da4b471883279cd913d162323434