### PR TITLE
Shrink map frame size

### DIFF
--- a/mercenary_territory_ui_sample.html
+++ b/mercenary_territory_ui_sample.html
@@ -303,6 +303,8 @@
             border: 2px solid rgba(255, 255, 255, 0.1);
             position: relative;
             overflow: hidden;
+            width: 2880px;
+            height: 1920px;
         }
         
         #territory-map::before {


### PR DESCRIPTION
## Summary
- bring the territory map down to the same size as the initial game canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870e0e0e3f48327b61feb604358ac55